### PR TITLE
firebase-jobdispatcher to built-in jobscheduler

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,7 +108,6 @@ dependencies {
     compile "com.squareup.retrofit2:retrofit:${retrofit}"
     compile "com.squareup.retrofit2:converter-gson:${retrofit}"
     compile "com.squareup.retrofit2:adapter-rxjava:${retrofit}"
-    compile 'com.firebase:firebase-jobdispatcher:0.5.2'
     compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
     compile 'cn.gavinliu.android.lib:ShapedImageView:0.8.3'
     compile "frankiesardo:icepick:${icepickVersion}"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -193,10 +193,7 @@
 
         <service
             android:name=".provider.tasks.notification.NotificationSchedulerJobTask"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="com.firebase.jobdispatcher.ACTION_EXECUTE"/>
-            </intent-filter>
+            android:permission="android.permission.BIND_JOB_SERVICE">
         </service>
         <service android:name=".provider.tasks.notification.ReadNotificationService"/>
         <service android:name=".provider.tasks.git.GithubActionService"/>

--- a/app/src/main/java/com/fastaccess/helper/PrefGetter.java
+++ b/app/src/main/java/com/fastaccess/helper/PrefGetter.java
@@ -10,6 +10,7 @@ import com.fastaccess.R;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by Kosh on 10 Nov 2016, 3:43 PM
@@ -110,19 +111,19 @@ public class PrefGetter {
         return PrefHelper.getBoolean("recylerViewAnimation");
     }
 
-    public static int getNotificationTaskDuration(@NonNull Context context) {
+    public static long getNotificationTaskDuration(@NonNull Context context) {
         String s = PrefHelper.getString("notificationTime");
         if (!InputHelper.isEmpty(s)) {
             if (s.equalsIgnoreCase(context.getString(R.string.thirty_minutes))) {
-                return 30 * 60;
+                return TimeUnit.MINUTES.toMillis(30);
             } else if (s.equalsIgnoreCase(context.getString(R.string.twenty_minutes))) {
-                return 20 * 60;
+                return TimeUnit.MINUTES.toMillis(20);
             } else if (s.equalsIgnoreCase(context.getString(R.string.ten_minutes))) {
-                return 10 * 60;
+                return TimeUnit.MINUTES.toMillis(10);
             } else if (s.equalsIgnoreCase(context.getString(R.string.five_minutes))) {
-                return 5 * 60;
+                return TimeUnit.MINUTES.toMillis(5);
             } else if (s.equalsIgnoreCase(context.getString(R.string.one_minute))) {
-                return 60;
+                return TimeUnit.MINUTES.toMillis(1);
             } else if (s.equalsIgnoreCase(context.getString(R.string.turn_off))) {
                 return -1;
             }


### PR DESCRIPTION
A better and easier approach than evernote, since minsdk is set to 21 anyway.
firebase-jobdispatcher in this case is just using the built-in one, so it's cutting out the middleman. If you would have minsdk<21, firebase or evernote would be using other routes available, GCM for firebase or GCM/AlarmManager for evernote.

Please test that there is no bug associated with GCM calling a class which is not for GCM anymore as mentioned here: https://github.com/evernote/android-job/blob/master/FAQ.md#how-can-i-remove-the-gcm-dependency-from-my-app . I don't know if it applies to firebase-jobdispatcher and/or api 21+, where GCM shouldn't have been used, as well.
Only you can do it, having the keys for both gcm and apk signing, so you can overwrite one version over the previous :+1: 
How to test:

1. Start app(release config with gcm) with current approach, an older build for the PlayStore should work
2. Install over it one built with this branch
3. Wait for the notification period to pass(30 minutes, or maybe even decrease it earlier on?)
4. See if there was a crash

Fixes #274 