### PR TITLE
Fix Issues #322, #405, #466, #475, and #487 & Various changes.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,6 +148,7 @@ dependencies {
     compile 'com.github.nightwhistler:HtmlSpanner:0.4'
     compile 'net.sourceforge.htmlcleaner:htmlcleaner:2.2'
     compile 'com.github.matthiasrobbers:shortbread:1.0.1'
+    compile 'com.linkedin.android.spyglass:spyglass:1.4.0'
     provided "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor 'io.requery:requery-processor:1.2.0'
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/app/src/main/java/com/fastaccess/data/dao/FragmentPagerAdapterModel.java
+++ b/app/src/main/java/com/fastaccess/data/dao/FragmentPagerAdapterModel.java
@@ -10,9 +10,11 @@ import com.fastaccess.R;
 import com.fastaccess.data.dao.model.Commit;
 import com.fastaccess.data.dao.model.Gist;
 import com.fastaccess.data.dao.model.Issue;
+import com.fastaccess.data.dao.model.Login;
 import com.fastaccess.data.dao.model.PullRequest;
 import com.fastaccess.data.dao.types.IssueState;
 import com.fastaccess.data.dao.types.MyIssuesType;
+import com.fastaccess.ui.modules.gists.GistsFragment;
 import com.fastaccess.ui.modules.gists.gist.comments.GistCommentsFragment;
 import com.fastaccess.ui.modules.gists.gist.files.GistFilesListFragment;
 import com.fastaccess.ui.modules.main.issues.MyIssuesFragment;
@@ -156,6 +158,12 @@ import lombok.Setter;
 
         return Stream.of(new FragmentPagerAdapterModel(context.getString(R.string.unread), new UnreadNotificationsFragment()),
                 new FragmentPagerAdapterModel(context.getString(R.string.all), new AllNotificationsFragment())).collect(Collectors.toList());
+    }
+
+    public static List<FragmentPagerAdapterModel> buildForGists(@NonNull Context context) {
+
+        return Stream.of(new FragmentPagerAdapterModel(context.getString(R.string.my_gists), ProfileGistsFragment.newInstance(Login.getUser().getLogin())),
+                new FragmentPagerAdapterModel(context.getString(R.string.public_gists), GistsFragment.newInstance())).collect(Collectors.toList());
     }
 
     public static List<FragmentPagerAdapterModel> buildForMyIssues(@NonNull Context context) {

--- a/app/src/main/java/com/fastaccess/helper/ViewHelper.java
+++ b/app/src/main/java/com/fastaccess/helper/ViewHelper.java
@@ -150,7 +150,6 @@ public class ViewHelper {
 
     public static boolean isTablet(@NonNull Activity activity) {
         DisplayMetrics metrics = new DisplayMetrics();
-        activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
 
         float yInches = metrics.heightPixels / metrics.ydpi;
         float xInches = metrics.widthPixels / metrics.xdpi;

--- a/app/src/main/java/com/fastaccess/ui/adapter/viewholder/FeedsViewHolder.java
+++ b/app/src/main/java/com/fastaccess/ui/adapter/viewholder/FeedsViewHolder.java
@@ -3,6 +3,7 @@ package com.fastaccess.ui.adapter.viewholder;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.Html;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,6 +14,7 @@ import com.fastaccess.data.dao.model.Event;
 import com.fastaccess.data.dao.types.EventsType;
 import com.fastaccess.helper.InputHelper;
 import com.fastaccess.helper.ParseDateFormat;
+import com.fastaccess.provider.markdown.MarkDownProvider;
 import com.fastaccess.ui.widgets.AvatarLayout;
 import com.fastaccess.ui.widgets.FontTextView;
 import com.fastaccess.ui.widgets.SpannableBuilder;
@@ -123,7 +125,7 @@ public class FeedsViewHolder extends BaseViewHolder<Event> {
         }
         if (eventsModel.getPayload() != null) {
             if (eventsModel.getPayload().getComment() != null) {
-                description.setText(eventsModel.getPayload().getComment().getBody());
+                MarkDownProvider.setMdText(description, eventsModel.getPayload().getComment().getBody());
                 description.setVisibility(View.VISIBLE);
                 if (eventsModel.getPayload().getIssue() != null) {
                     number = "#" + eventsModel.getPayload().getIssue().getNumber();

--- a/app/src/main/java/com/fastaccess/ui/adapter/viewholder/ReposViewHolder.java
+++ b/app/src/main/java/com/fastaccess/ui/adapter/viewholder/ReposViewHolder.java
@@ -41,7 +41,7 @@ public class ReposViewHolder extends BaseViewHolder<Repo> {
     @BindString(R.string.forked) String forked;
     @BindString(R.string.private_repo) String privateRepo;
     @BindColor(R.color.material_indigo_700) int forkColor;
-    @BindColor(R.color.material_deep_purple_700) int privateColor;
+    @BindColor(R.color.material_grey_700) int privateColor;
     private boolean isStarred;
     private boolean withImage;
 

--- a/app/src/main/java/com/fastaccess/ui/base/BaseActivity.java
+++ b/app/src/main/java/com/fastaccess/ui/base/BaseActivity.java
@@ -212,8 +212,6 @@ public abstract class BaseActivity<V extends BaseMvp.FAView, P extends BasePrese
             if (isFinishing()) return;
             if (item.getItemId() == R.id.navToRepo) {
                 onNavToRepoClicked();
-            } else if (item.getItemId() == R.id.fhRepo) {
-                startActivity(RepoPagerActivity.createIntent(this, "FastHub", "k0shk0sh"));
             } else if (item.getItemId() == R.id.supportDev) {
                 startActivity(new Intent(this, DonationActivity.class));
             } else if (item.getItemId() == R.id.gists) {

--- a/app/src/main/java/com/fastaccess/ui/base/BaseActivity.java
+++ b/app/src/main/java/com/fastaccess/ui/base/BaseActivity.java
@@ -35,6 +35,7 @@ import com.fastaccess.helper.PrefGetter;
 import com.fastaccess.helper.ViewHelper;
 import com.fastaccess.ui.base.mvp.BaseMvp;
 import com.fastaccess.ui.base.mvp.presenter.BasePresenter;
+import com.fastaccess.ui.modules.about.FastHubAboutActivity;
 import com.fastaccess.ui.modules.changelog.ChangelogBottomSheetDialog;
 import com.fastaccess.ui.modules.gists.GistsListActivity;
 import com.fastaccess.ui.modules.login.LoginChooserActivity;
@@ -216,8 +217,6 @@ public abstract class BaseActivity<V extends BaseMvp.FAView, P extends BasePrese
                 startActivity(new Intent(this, DonationActivity.class));
             } else if (item.getItemId() == R.id.gists) {
                 GistsListActivity.startActivity(this, false);
-            } else if (item.getItemId() == R.id.myGists) {
-                GistsListActivity.startActivity(this, true);
             } else if (item.getItemId() == R.id.pinnedMenu) {
                 PinnedReposActivity.startActivity(this);
             } else if (item.getItemId() == R.id.mainView) {
@@ -231,6 +230,8 @@ public abstract class BaseActivity<V extends BaseMvp.FAView, P extends BasePrese
                 onLogoutPressed();
             } else if (item.getItemId() == R.id.settings) {
                 onOpenSettings();
+            } else if (item.getItemId() == R.id.about) {
+                startActivity(new Intent(this, FastHubAboutActivity.class));
             } else if (item.getItemId() == R.id.orgs) {
                 onOpenOrgsDialog();
             } else if (item.getItemId() == R.id.notifications) {
@@ -300,15 +301,6 @@ public abstract class BaseActivity<V extends BaseMvp.FAView, P extends BasePrese
         if (extraNav != null) {
             extraNav.getMenu().findItem(R.id.profile).setCheckable(true);
             extraNav.getMenu().findItem(R.id.profile).setChecked(true);
-        }
-    }
-
-    protected void selectGists(boolean publicGists) {
-        if (extraNav != null) {
-            extraNav.getMenu().findItem(R.id.gists).setCheckable(publicGists);
-            extraNav.getMenu().findItem(R.id.gists).setChecked(publicGists);
-            extraNav.getMenu().findItem(R.id.myGists).setCheckable(!publicGists);
-            extraNav.getMenu().findItem(R.id.myGists).setChecked(!publicGists);
         }
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/editor/EditorActivity.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/editor/EditorActivity.java
@@ -12,6 +12,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
+import android.widget.LinearLayout;
 
 import com.fastaccess.R;
 import com.fastaccess.data.dao.model.Comment;
@@ -28,6 +29,7 @@ import com.fastaccess.provider.markdown.MarkDownProvider;
 import com.fastaccess.ui.base.BaseActivity;
 import com.fastaccess.ui.modules.editor.popup.EditorLinkImageDialogFragment;
 import com.fastaccess.ui.widgets.FontEditText;
+import com.fastaccess.ui.widgets.FontTextView;
 import com.fastaccess.ui.widgets.ForegroundImageView;
 import com.fastaccess.ui.widgets.dialog.MessageDialogView;
 
@@ -36,6 +38,8 @@ import butterknife.OnClick;
 import butterknife.OnTextChanged;
 import icepick.State;
 import uk.co.samuelwall.materialtaptargetprompt.MaterialTapTargetPrompt;
+
+import static android.view.View.GONE;
 
 /**
  * Created by Kosh on 27 Nov 2016, 1:32 AM
@@ -46,6 +50,8 @@ public class EditorActivity extends BaseActivity<EditorMvp.View, EditorPresenter
     private String sentFromFastHub;
 
     private CharSequence savedText = "";
+    @BindView(R.id.replyQuote) LinearLayout replyQuote;
+    @BindView(R.id.replyQuoteText) FontTextView quote;
     @BindView(R.id.view) ForegroundImageView viewCode;
     @BindView(R.id.editText) FontEditText editText;
     @BindView(R.id.editorIconsHolder) View editorIconsHolder;
@@ -122,7 +128,7 @@ public class EditorActivity extends BaseActivity<EditorMvp.View, EditorPresenter
         setToolbarIcon(R.drawable.ic_clear);
         sentFromFastHub = "\n\n_" + getString(R.string.sent_from_fasthub, AppHelper.getDeviceName(), "",
                 "[" + getString(R.string.app_name) + "](https://play.google.com/store/apps/details?id=com.fastaccess.github)") + "_";
-        sentVia.setVisibility(PrefGetter.isSentViaBoxEnabled() ? View.VISIBLE : View.GONE);
+        sentVia.setVisibility(PrefGetter.isSentViaBoxEnabled() ? View.VISIBLE : GONE);
         sentVia.setChecked(PrefGetter.isSentViaEnabled());
         sentVia.setOnCheckedChangeListener((buttonView, isChecked) -> {
             PrefHelper.set("sent_via", isChecked);
@@ -148,6 +154,10 @@ public class EditorActivity extends BaseActivity<EditorMvp.View, EditorPresenter
                     editText.setText(String.format("%s ", textToUpdate));
                     editText.setSelection(InputHelper.toString(editText).length());
                 }
+                if(bundle.getString("message", "").isEmpty())
+                    replyQuote.setVisibility(GONE);
+                else
+                    MarkDownProvider.setMdText(quote, bundle.getString("message", ""));
             }
         }
         if (!PrefGetter.isEditorHintShowed()) {

--- a/app/src/main/java/com/fastaccess/ui/modules/gists/GistsListActivity.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/gists/GistsListActivity.java
@@ -5,16 +5,20 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
+import android.support.design.widget.TabLayout;
 
 import com.fastaccess.R;
+import com.fastaccess.data.dao.FragmentPagerAdapterModel;
 import com.fastaccess.data.dao.model.Login;
 import com.fastaccess.helper.ActivityHelper;
 import com.fastaccess.helper.BundleConstant;
 import com.fastaccess.helper.Bundler;
+import com.fastaccess.ui.adapter.FragmentsPagerAdapter;
 import com.fastaccess.ui.base.BaseActivity;
 import com.fastaccess.ui.base.mvp.presenter.BasePresenter;
 import com.fastaccess.ui.modules.gists.create.CreateGistActivity;
 import com.fastaccess.ui.modules.profile.gists.ProfileGistsFragment;
+import com.fastaccess.ui.widgets.ViewPagerView;
 
 import net.grandcentrix.thirtyinch.TiPresenter;
 
@@ -28,6 +32,11 @@ import icepick.State;
 
 public class GistsListActivity extends BaseActivity {
 
+    @BindView(R.id.tabs)
+    TabLayout tabs;
+    @BindView(R.id.gistsContainer)
+    ViewPagerView pager;
+
     public static void startActivity(@NonNull Context context, boolean myGists) {
         Intent intent = new Intent(context, GistsListActivity.class);
         intent.putExtras(Bundler.start().put(BundleConstant.EXTRA, myGists).end());
@@ -39,7 +48,7 @@ public class GistsListActivity extends BaseActivity {
     @BindView(R.id.fab) FloatingActionButton fab;
 
     @Override protected int layout() {
-        return R.layout.toolbar_activity_layout;
+        return R.layout.gists_activity_layout;
     }
 
     @Override protected boolean isTransparent() {
@@ -60,17 +69,23 @@ public class GistsListActivity extends BaseActivity {
 
     @Override protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (savedInstanceState == null) {
-            myGists = getIntent().getExtras().getBoolean(BundleConstant.EXTRA);
-            getSupportFragmentManager()
-                    .beginTransaction()
-                    .replace(R.id.fragmentContainer, myGists ? ProfileGistsFragment.newInstance(Login.getUser().getLogin())
-                                                             : GistsFragment.newInstance(), GistsFragment.TAG)
-                    .commit();
-        }
-        selectGists(!myGists);
-        setTitle(myGists ? R.string.my_gists : R.string.public_gists);
+        setTitle(R.string.gists);
+        setupTabs();
         fab.show();
+    }
+
+    private void setupTabs() {
+        TabLayout.Tab tab1 = getTab(R.string.my_gists);
+        TabLayout.Tab tab2 = getTab(R.string.public_gists);
+        tabs.addTab(tab1);
+        tabs.addTab(tab2);
+        pager.setAdapter(new FragmentsPagerAdapter(getSupportFragmentManager(),
+                FragmentPagerAdapterModel.buildForGists(this)));
+        tabs.setupWithViewPager(pager);
+    }
+
+    private TabLayout.Tab getTab(int titleId) {
+        return tabs.newTab().setText(titleId);
     }
 
     @OnClick(R.id.fab) public void onViewClicked() {

--- a/app/src/main/java/com/fastaccess/ui/modules/gists/gist/comments/GistCommentsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/gists/gist/comments/GistCommentsFragment.java
@@ -179,6 +179,19 @@ refresh.setRefreshing(true);
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
     }
 
+    @Override public void onReply(User user, String message) {
+        Intent intent = new Intent(getContext(), EditorActivity.class);
+        intent.putExtras(Bundler
+                .start()
+                .put(BundleConstant.ID, gistId)
+                .put(BundleConstant.EXTRA, "@" + user.getLogin())
+                .put(BundleConstant.EXTRA_TYPE, NEW_GIST_COMMENT_EXTRA)
+                .put("message", message)
+                .end());
+        View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
+        ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
+    }
+
     @Override public void onDestroyView() {
         recycler.removeOnScrollListener(getLoadMore());
         super.onDestroyView();

--- a/app/src/main/java/com/fastaccess/ui/modules/gists/gist/comments/GistCommentsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/gists/gist/comments/GistCommentsFragment.java
@@ -2,6 +2,7 @@ package com.fastaccess.ui.modules.gists.gist.comments;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -9,8 +10,11 @@ import android.support.annotation.StringRes;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.View;
 
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Stream;
 import com.fastaccess.R;
 import com.fastaccess.data.dao.SparseBooleanArrayParcelable;
+import com.fastaccess.data.dao.TimelineModel;
 import com.fastaccess.data.dao.model.Comment;
 import com.fastaccess.data.dao.model.User;
 import com.fastaccess.helper.ActivityHelper;
@@ -24,6 +28,9 @@ import com.fastaccess.ui.widgets.StateLayout;
 import com.fastaccess.ui.widgets.dialog.MessageDialogView;
 import com.fastaccess.ui.widgets.recyclerview.DynamicRecyclerView;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 
 import butterknife.BindView;
@@ -45,6 +52,8 @@ public class GistCommentsFragment extends BaseFragment<GistCommentsMvp.View, Gis
     private String gistId;
     private CommentsAdapter adapter;
     private OnLoadMore<String> onLoadMore;
+
+    private ArrayList<String> participants;
 
     public static GistCommentsFragment newInstance(@NonNull String gistId) {
         GistCommentsFragment view = new GistCommentsFragment();
@@ -83,6 +92,16 @@ public class GistCommentsFragment extends BaseFragment<GistCommentsMvp.View, Gis
 
     @Override public void onNotifyAdapter(@Nullable List<Comment> items, int page) {
         hideProgress();
+
+        participants = null;
+        participants = (ArrayList<String>) Stream.of(items)
+                .map(comment -> comment.getUser().getLogin())
+                .collect(Collectors.toList());
+        HashSet<String> hashSet = new HashSet<String>();
+        hashSet.addAll(participants);
+        participants.clear();
+        participants.addAll(hashSet);
+
         if (items == null || items.isEmpty()) {
             adapter.clear();
             return;
@@ -107,7 +126,7 @@ public class GistCommentsFragment extends BaseFragment<GistCommentsMvp.View, Gis
 
     @Override public void showProgress(@StringRes int resId) {
 
-refresh.setRefreshing(true);
+        refresh.setRefreshing(true);
 
         stateLayout.showProgress();
     }
@@ -141,6 +160,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.EXTRA, item.getBody())
                 .put(BundleConstant.EXTRA_FOUR, item.getId())
                 .put(BundleConstant.EXTRA_TYPE, EDIT_GIST_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
@@ -152,6 +172,7 @@ refresh.setRefreshing(true);
                 .start()
                 .put(BundleConstant.ID, gistId)
                 .put(BundleConstant.EXTRA_TYPE, NEW_GIST_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
@@ -163,6 +184,7 @@ refresh.setRefreshing(true);
                         .put(BundleConstant.EXTRA, id)
                         .put(BundleConstant.ID, gistId)
                         .put(BundleConstant.YES_NO_EXTRA, true)
+                        .putStringArrayList("participants", participants)
                         .end())
                 .show(getChildFragmentManager(), MessageDialogView.TAG);
     }
@@ -174,6 +196,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.ID, gistId)
                 .put(BundleConstant.EXTRA, "@" + user.getLogin())
                 .put(BundleConstant.EXTRA_TYPE, NEW_GIST_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
@@ -186,6 +209,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.ID, gistId)
                 .put(BundleConstant.EXTRA, "@" + user.getLogin())
                 .put(BundleConstant.EXTRA_TYPE, NEW_GIST_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .put("message", message)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;

--- a/app/src/main/java/com/fastaccess/ui/modules/gists/gist/comments/GistCommentsMvp.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/gists/gist/comments/GistCommentsMvp.java
@@ -36,6 +36,8 @@ interface GistCommentsMvp {
         void onShowDeleteMsg(long id);
 
         void onTagUser(@NonNull User user);
+
+        void onReply(User user, String message);
     }
 
     interface Presenter extends BaseMvp.FAPresenter,

--- a/app/src/main/java/com/fastaccess/ui/modules/gists/gist/comments/GistCommentsPresenter.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/gists/gist/comments/GistCommentsPresenter.java
@@ -115,7 +115,7 @@ class GistCommentsPresenter extends BasePresenter<GistCommentsMvp.View> implemen
                 if (item1.getItemId() == R.id.delete) {
                     getView().onShowDeleteMsg(item.getId());
                 } else if (item1.getItemId() == R.id.reply) {
-                    getView().onTagUser(item.getUser());
+                    getView().onReply(item.getUser(), item.getBody());
                 } else if (item1.getItemId() == R.id.edit) {
                     getView().onEditComment(item);
                 }

--- a/app/src/main/java/com/fastaccess/ui/modules/login/LoginActivity.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/login/LoginActivity.java
@@ -14,16 +14,24 @@ import android.support.design.widget.TextInputLayout;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
 
+import com.fastaccess.BuildConfig;
 import com.fastaccess.R;
 import com.fastaccess.helper.ActivityHelper;
 import com.fastaccess.helper.AnimHelper;
 import com.fastaccess.helper.BundleConstant;
 import com.fastaccess.helper.Bundler;
 import com.fastaccess.helper.InputHelper;
+import com.fastaccess.helper.PrefHelper;
 import com.fastaccess.ui.base.BaseActivity;
 import com.fastaccess.ui.modules.main.MainActivity;
+import com.fastaccess.ui.modules.settings.LanguageBottomSheetDialog;
 import com.fastaccess.ui.modules.settings.SlackBottomSheetDialog;
+import com.fastaccess.ui.widgets.FontEditText;
+
+import java.util.Arrays;
+import java.util.Locale;
 
 import butterknife.BindView;
 import butterknife.OnClick;
@@ -38,7 +46,7 @@ import icepick.State;
 
 public class LoginActivity extends BaseActivity<LoginMvp.View, LoginPresenter> implements LoginMvp.View {
 
-
+    @Nullable @BindView(R.id.language_selector) RelativeLayout language_selector;
     @Nullable @BindView(R.id.usernameEditText) TextInputEditText usernameEditText;
     @Nullable @BindView(R.id.username) TextInputLayout username;
     @Nullable @BindView(R.id.passwordEditText) TextInputEditText passwordEditText;
@@ -82,6 +90,10 @@ public class LoginActivity extends BaseActivity<LoginMvp.View, LoginPresenter> i
     @Optional @OnEditorAction(R.id.twoFactorEditText) public boolean onSend2FA() {
         doLogin();
         return true;
+    }
+
+    @Optional @OnClick(R.id.language_selector_clicker) public void onChangeLanguage() {
+        showLanguage();
     }
 
     @Override protected int layout() {
@@ -139,6 +151,20 @@ public class LoginActivity extends BaseActivity<LoginMvp.View, LoginPresenter> i
             }
         }
         if (password != null) password.setHint(isBasicAuth ? getString(R.string.password) : getString(R.string.access_token));
+        if (Arrays.asList(getResources().getStringArray(R.array.languages_array_values)).contains(Locale.getDefault().getLanguage())){
+            String language = PrefHelper.getString("app_language");
+            PrefHelper.set("app_language", Locale.getDefault().getLanguage());
+            if(!BuildConfig.DEBUG)
+                language_selector.setVisibility(View.GONE);
+            if(!Locale.getDefault().getLanguage().equals(language))
+                recreate();
+        }
+    }
+
+    private void showLanguage() {
+        LanguageBottomSheetDialog languageBottomSheetDialog = new LanguageBottomSheetDialog();
+        languageBottomSheetDialog.onAttach((Context) this);
+        languageBottomSheetDialog.show(getSupportFragmentManager(), "LanguageBottomSheetDialog");
     }
 
     @Override protected void onNewIntent(Intent intent) {

--- a/app/src/main/java/com/fastaccess/ui/modules/pinned/PinnedReposFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/pinned/PinnedReposFragment.java
@@ -8,6 +8,7 @@ import android.view.View;
 import com.fastaccess.R;
 import com.fastaccess.data.dao.model.AbstractPinnedRepos;
 import com.fastaccess.data.dao.model.PinnedRepos;
+import com.fastaccess.data.dao.model.Repo;
 import com.fastaccess.helper.BundleConstant;
 import com.fastaccess.helper.Bundler;
 import com.fastaccess.ui.adapter.PinnedReposAdapter;
@@ -59,6 +60,8 @@ public class PinnedReposFragment extends BaseFragment<PinnedReposMvp.View, Pinne
     }
 
     @Override protected void onFragmentCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        if(!AbstractPinnedRepos.isPinned("k0shk0sh/FastHub"))
+            Repo.getRepo("FastHub", "k0shk0sh").subscribe(AbstractPinnedRepos::pinUpin);
         adapter = new PinnedReposAdapter(getPresenter().getPinnedRepos(), getPresenter());
         stateLayout.setEmptyText(R.string.empty_pinned_repos);
         recycler.setEmptyView(stateLayout, refresh);

--- a/app/src/main/java/com/fastaccess/ui/modules/pinned/PinnedReposPresenter.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/pinned/PinnedReposPresenter.java
@@ -39,6 +39,9 @@ public class PinnedReposPresenter extends BasePresenter<PinnedReposMvp.View> imp
     }
 
     @Override public void onItemLongClick(int position, View v, PinnedRepos item) {
+        if (item!=null)
+            if (item.getRepoFullName().equalsIgnoreCase("k0shk0sh/FastHub"))
+                return;
         if (getView() != null) {
             getView().onDeletePinnedRepo(item.getId(), position);
         }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/details/comments/CommitCommentsFragments.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/details/comments/CommitCommentsFragments.java
@@ -179,6 +179,21 @@ refresh.setRefreshing(true);
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
     }
 
+    @Override public void onReply(User user, String message) {
+        Intent intent = new Intent(getContext(), EditorActivity.class);
+        intent.putExtras(Bundler
+                .start()
+                .put(BundleConstant.ID, getPresenter().repoId())
+                .put(BundleConstant.EXTRA_TWO, getPresenter().login())
+                .put(BundleConstant.EXTRA_THREE, getPresenter().sha())
+                .put(BundleConstant.EXTRA, "@" + user.getLogin())
+                .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.NEW_COMMIT_COMMENT_EXTRA)
+                .put("message", message)
+                .end());
+        View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
+        ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
+    }
+
     @Override public void showReactionsPopup(@NonNull ReactionTypes reactionTypes, @NonNull String login, @NonNull String repoId, long commentId) {
         ReactionsDialogFragment.newInstance(login, repoId, reactionTypes, commentId, ReactionsProvider.COMMIT)
                 .show(getChildFragmentManager(), "ReactionsDialogFragment");

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/details/comments/CommitCommentsFragments.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/details/comments/CommitCommentsFragments.java
@@ -2,6 +2,7 @@ package com.fastaccess.ui.modules.repos.code.commit.details.comments;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -9,6 +10,8 @@ import android.support.annotation.StringRes;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.View;
 
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Stream;
 import com.fastaccess.R;
 import com.fastaccess.data.dao.SparseBooleanArrayParcelable;
 import com.fastaccess.data.dao.TimelineModel;
@@ -28,6 +31,9 @@ import com.fastaccess.ui.widgets.StateLayout;
 import com.fastaccess.ui.widgets.dialog.MessageDialogView;
 import com.fastaccess.ui.widgets.recyclerview.DynamicRecyclerView;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 
 import butterknife.BindView;
@@ -46,6 +52,8 @@ public class CommitCommentsFragments extends BaseFragment<CommitCommentsMvp.View
 
     private IssuePullsTimelineAdapter adapter;
     private OnLoadMore onLoadMore;
+
+    private ArrayList<String> participants;
 
     public static CommitCommentsFragments newInstance(@NonNull String login, @NonNull String repoId, @NonNull String sha) {
         CommitCommentsFragments view = new CommitCommentsFragments();
@@ -87,6 +95,17 @@ public class CommitCommentsFragments extends BaseFragment<CommitCommentsMvp.View
 
     @Override public void onNotifyAdapter(@Nullable List<TimelineModel> items, int page) {
         hideProgress();
+
+        participants = null;
+        participants = (ArrayList<String>) Stream.of(items)
+                .filter(value -> value.getType() == TimelineModel.COMMENT)
+                .map(value -> value.getComment()).map(comment-> comment.getUser().getLogin())
+                .collect(Collectors.toList());
+        HashSet<String> hashSet = new HashSet<String>();
+        hashSet.addAll(participants);
+        participants.clear();
+        participants.addAll(hashSet);
+
         if (items == null || items.isEmpty()) {
             adapter.clear();
             return;
@@ -147,6 +166,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.EXTRA_FOUR, item.getId())
                 .put(BundleConstant.EXTRA, item.getBody())
                 .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.EDIT_COMMIT_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
@@ -174,6 +194,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.EXTRA_THREE, getPresenter().sha())
                 .put(BundleConstant.EXTRA, user != null ? "@" + user.getLogin() : "")
                 .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.NEW_COMMIT_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
@@ -188,6 +209,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.EXTRA_THREE, getPresenter().sha())
                 .put(BundleConstant.EXTRA, "@" + user.getLogin())
                 .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.NEW_COMMIT_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .put("message", message)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/details/comments/CommitCommentsMvp.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/details/comments/CommitCommentsMvp.java
@@ -41,6 +41,8 @@ interface CommitCommentsMvp {
 
         void onTagUser(@Nullable User user);
 
+        void onReply(User user, String message);
+
         void showReactionsPopup(@NonNull ReactionTypes reactionTypes, @NonNull String login, @NonNull String repoId, long commentId);
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/details/comments/CommitCommentsPresenter.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/details/comments/CommitCommentsPresenter.java
@@ -145,7 +145,7 @@ class CommitCommentsPresenter extends BasePresenter<CommitCommentsMvp.View> impl
                     if (item1.getItemId() == R.id.delete) {
                         getView().onShowDeleteMsg(item.getId());
                     } else if (item1.getItemId() == R.id.reply) {
-                        getView().onTagUser(item.getUser());
+                        getView().onReply(item.getUser(), item.getBody());
                     } else if (item1.getItemId() == R.id.edit) {
                         getView().onEditComment(item);
                     } else if (item1.getItemId() == R.id.share) {

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/IssuePagerActivity.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/IssuePagerActivity.java
@@ -261,7 +261,7 @@ public class IssuePagerActivity extends BaseActivity<IssuePagerMvp.View, IssuePa
                     .append(" ")
                     .append(getString(issueModel.getState().getStatus()))
                     .append(" ").append(getString(R.string.by)).append(" ").append(username).append(" ")
-                    .append(parsedDate));
+                    .append(parsedDate).append("\n").append(issueModel.getRepoId()));
             avatarLayout.setUrl(userModel.getAvatarUrl(), userModel.getLogin());
         }
         pager.setAdapter(new FragmentsPagerAdapter(getSupportFragmentManager(), FragmentPagerAdapterModel.buildForIssues(this, issueModel)));

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelineFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelineFragment.java
@@ -163,6 +163,21 @@ refresh.setRefreshing(true);
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
     }
 
+    @Override public void onReply(User user, String message) {
+        Intent intent = new Intent(getContext(), EditorActivity.class);
+        intent.putExtras(Bundler
+                .start()
+                .put(BundleConstant.ID, getPresenter().repoId())
+                .put(BundleConstant.EXTRA_TWO, getPresenter().login())
+                .put(BundleConstant.EXTRA_THREE, getPresenter().number())
+                .put(BundleConstant.EXTRA, "@" + user.getLogin())
+                .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.NEW_ISSUE_COMMENT_EXTRA)
+                .put("message", message)
+                .end());
+        View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
+        ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
+    }
+
     @Override public void showReactionsPopup(@NonNull ReactionTypes type, @NonNull String login,
                                              @NonNull String repoId, long idOrNumber, boolean isHeader) {
         ReactionsDialogFragment.newInstance(login, repoId, type, idOrNumber, isHeader ? ReactionsProvider.HEADER : ReactionsProvider.COMMENT)

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelineFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelineFragment.java
@@ -79,8 +79,6 @@ public class IssueTimelineFragment extends BaseFragment<IssueTimelineMvp.View, I
         participants.clear();
         participants.addAll(hashSet);
 
-        System.out.println("READ THIS: " + participants);
-
         if (items == null || items.isEmpty()) {
             adapter.clear();
             return;

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelineFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelineFragment.java
@@ -2,12 +2,15 @@ package com.fastaccess.ui.modules.repos.issues.issue.details.timeline;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.view.View;
 
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Stream;
 import com.fastaccess.R;
 import com.fastaccess.data.dao.SparseBooleanArrayParcelable;
 import com.fastaccess.data.dao.TimelineModel;
@@ -30,6 +33,9 @@ import com.fastaccess.ui.widgets.dialog.MessageDialogView;
 import com.fastaccess.ui.widgets.recyclerview.DynamicRecyclerView;
 import com.fastaccess.ui.widgets.recyclerview.scroll.RecyclerFastScroller;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 
 import butterknife.BindView;
@@ -48,6 +54,8 @@ public class IssueTimelineFragment extends BaseFragment<IssueTimelineMvp.View, I
     private IssuePullsTimelineAdapter adapter;
     @State SparseBooleanArrayParcelable sparseBooleanArray;
 
+    private ArrayList<String> participants;
+
     public static IssueTimelineFragment newInstance(@NonNull Issue issueModel) {
         IssueTimelineFragment view = new IssueTimelineFragment();
         view.setArguments(Bundler.start().put(BundleConstant.ITEM, issueModel).end());//TODO fix this
@@ -60,6 +68,19 @@ public class IssueTimelineFragment extends BaseFragment<IssueTimelineMvp.View, I
 
     @Override public void onNotifyAdapter(@Nullable List<TimelineModel> items) {
         hideProgress();
+
+        participants = null;
+        participants = (ArrayList<String>) Stream.of(items)
+                .filter(value -> value.getType() == TimelineModel.COMMENT)
+                .map(value -> value.getComment()).map(comment-> comment.getUser().getLogin())
+                .collect(Collectors.toList());
+        HashSet<String> hashSet = new HashSet<String>();
+        hashSet.addAll(participants);
+        participants.clear();
+        participants.addAll(hashSet);
+
+        System.out.println("READ THIS: " + participants);
+
         if (items == null || items.isEmpty()) {
             adapter.clear();
             return;
@@ -96,7 +117,7 @@ public class IssueTimelineFragment extends BaseFragment<IssueTimelineMvp.View, I
 
     @Override public void showProgress(@StringRes int resId) {
 
-refresh.setRefreshing(true);
+        refresh.setRefreshing(true);
 
         stateLayout.showProgress();
     }
@@ -126,6 +147,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.EXTRA_FOUR, item.getId())
                 .put(BundleConstant.EXTRA, item.getBody())
                 .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.EDIT_ISSUE_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
@@ -145,6 +167,7 @@ refresh.setRefreshing(true);
                 Bundler.start()
                         .put(BundleConstant.EXTRA, id)
                         .put(BundleConstant.YES_NO_EXTRA, true)
+                        .putStringArrayList("participants", participants)
                         .end())
                 .show(getChildFragmentManager(), MessageDialogView.TAG);
     }
@@ -158,6 +181,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.EXTRA_THREE, getPresenter().number())
                 .put(BundleConstant.EXTRA, user != null ? "@" + user.getLogin() : "")
                 .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.NEW_ISSUE_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
@@ -172,6 +196,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.EXTRA_THREE, getPresenter().number())
                 .put(BundleConstant.EXTRA, "@" + user.getLogin())
                 .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.NEW_ISSUE_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .put("message", message)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelineMvp.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelineMvp.java
@@ -40,6 +40,8 @@ public interface IssueTimelineMvp {
 
         void onTagUser(@Nullable User user);
 
+        void onReply(User user, String message);
+
         void showReactionsPopup(@NonNull ReactionTypes type, @NonNull String login, @NonNull String repoId, long idOrNumber, boolean isHeadre);
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelinePresenter.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelinePresenter.java
@@ -79,7 +79,7 @@ public class IssueTimelinePresenter extends BasePresenter<IssueTimelineMvp.View>
                         if (item1.getItemId() == R.id.delete) {
                             getView().onShowDeleteMsg(item.getComment().getId());
                         } else if (item1.getItemId() == R.id.reply) {
-                            getView().onTagUser(item.getComment().getUser());
+                            getView().onReply(item.getComment().getUser(), item.getComment().getBody());
                         } else if (item1.getItemId() == R.id.edit) {
                             getView().onEditComment(item.getComment());
                         } else if (item1.getItemId() == R.id.share) {
@@ -106,7 +106,7 @@ public class IssueTimelinePresenter extends BasePresenter<IssueTimelineMvp.View>
                     popupMenu.setOnMenuItemClickListener(item1 -> {
                         if (getView() == null) return false;
                         if (item1.getItemId() == R.id.reply) {
-                            getView().onTagUser(item.getIssue().getUser());
+                            getView().onReply(item.getIssue().getUser(), item.getIssue().getBody());
                         } else if (item1.getItemId() == R.id.edit) {
                             Activity activity = ActivityHelper.getActivity(v.getContext());
                             if (activity == null) return false;

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/PullRequestPagerActivity.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/PullRequestPagerActivity.java
@@ -248,7 +248,7 @@ public class PullRequestPagerActivity extends BaseActivity<PullRequestPagerMvp.V
         PullRequest pullRequest = getPresenter().getPullRequest();
         setTitle(String.format("#%s", pullRequest.getNumber()));
         boolean isMerge = !InputHelper.isEmpty(pullRequest.getMergedAt());
-        date.setText(getPresenter().getMergeBy(pullRequest, getApplicationContext()));
+        date.setText(getPresenter().getMergeBy(pullRequest, getApplicationContext())+"\n"+pullRequest.getRepoId());
         size.setVisibility(View.GONE);
         User userModel = pullRequest.getUser();
         if (userModel != null) {

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/timeline/timeline/PullRequestTimelineFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/timeline/timeline/PullRequestTimelineFragment.java
@@ -2,12 +2,15 @@ package com.fastaccess.ui.modules.repos.pull_requests.pull_request.details.timel
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.view.View;
 
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Stream;
 import com.fastaccess.R;
 import com.fastaccess.data.dao.ReviewCommentModel;
 import com.fastaccess.data.dao.SparseBooleanArrayParcelable;
@@ -30,6 +33,9 @@ import com.fastaccess.ui.widgets.dialog.MessageDialogView;
 import com.fastaccess.ui.widgets.recyclerview.DynamicRecyclerView;
 import com.fastaccess.ui.widgets.recyclerview.scroll.RecyclerFastScroller;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 
 import butterknife.BindView;
@@ -49,6 +55,8 @@ public class PullRequestTimelineFragment extends BaseFragment<PullRequestTimelin
     private IssuePullsTimelineAdapter adapter;
     @State SparseBooleanArrayParcelable sparseBooleanArray;
 
+    private ArrayList<String> participants;
+
     public static PullRequestTimelineFragment newInstance(@NonNull PullRequest pullRequest) {
         PullRequestTimelineFragment view = new PullRequestTimelineFragment();
         view.setArguments(Bundler.start().put(BundleConstant.ITEM, pullRequest).end());//TODO fix this
@@ -61,6 +69,17 @@ public class PullRequestTimelineFragment extends BaseFragment<PullRequestTimelin
 
     @Override public void onNotifyAdapter(@Nullable List<TimelineModel> items) {
         hideProgress();
+
+        participants = null;
+        participants = (ArrayList<String>) Stream.of(items)
+                .filter(value -> value.getType() == TimelineModel.COMMENT)
+                .map(value -> value.getComment()).map(comment-> comment.getUser().getLogin())
+                .collect(Collectors.toList());
+        HashSet<String> hashSet = new HashSet<String>();
+        hashSet.addAll(participants);
+        participants.clear();
+        participants.addAll(hashSet);
+
         if (items == null || items.isEmpty()) {
             adapter.clear();
             return;
@@ -141,6 +160,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.EXTRA_FOUR, item.getId())
                 .put(BundleConstant.EXTRA, item.getBody())
                 .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.EDIT_ISSUE_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
@@ -165,6 +185,7 @@ refresh.setRefreshing(true);
                         .put(BundleConstant.EXTRA, id)
                         .put(BundleConstant.YES_NO_EXTRA, true)
                         .put(BundleConstant.EXTRA_TWO, isReviewComment)
+                        .putStringArrayList("participants", participants)
                         .end())
                 .show(getChildFragmentManager(), MessageDialogView.TAG);
     }
@@ -178,6 +199,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.EXTRA_THREE, getPresenter().number())
                 .put(BundleConstant.EXTRA, user != null ? "@" + user.getLogin() : "")
                 .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.NEW_ISSUE_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
@@ -192,6 +214,7 @@ refresh.setRefreshing(true);
                 .put(BundleConstant.EXTRA_THREE, getPresenter().number())
                 .put(BundleConstant.EXTRA, "@" + user.getLogin())
                 .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.NEW_ISSUE_COMMENT_EXTRA)
+                .putStringArrayList("participants", participants)
                 .put("message", message)
                 .end());
         View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/timeline/timeline/PullRequestTimelineFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/timeline/timeline/PullRequestTimelineFragment.java
@@ -183,6 +183,21 @@ refresh.setRefreshing(true);
         ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
     }
 
+    @Override public void onReply(User user, String message) {
+        Intent intent = new Intent(getContext(), EditorActivity.class);
+        intent.putExtras(Bundler
+                .start()
+                .put(BundleConstant.ID, getPresenter().repoId())
+                .put(BundleConstant.EXTRA_TWO, getPresenter().login())
+                .put(BundleConstant.EXTRA_THREE, getPresenter().number())
+                .put(BundleConstant.EXTRA, "@" + user.getLogin())
+                .put(BundleConstant.EXTRA_TYPE, BundleConstant.ExtraTYpe.NEW_ISSUE_COMMENT_EXTRA)
+                .put("message", message)
+                .end());
+        View view = getActivity() != null && getActivity().findViewById(R.id.fab) != null ? getActivity().findViewById(R.id.fab) : recycler;
+        ActivityHelper.startReveal(this, intent, view, BundleConstant.REQUEST_CODE);
+    }
+
     @Override
     public void showReactionsPopup(@NonNull ReactionTypes type, @NonNull String login, @NonNull String repoId, long idOrNumber, int reactionType) {
         ReactionsDialogFragment.newInstance(login, repoId, type, idOrNumber, reactionType).show(getChildFragmentManager(), "ReactionsDialogFragment");

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/timeline/timeline/PullRequestTimelineMvp.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/timeline/timeline/PullRequestTimelineMvp.java
@@ -48,6 +48,8 @@ public interface PullRequestTimelineMvp {
 
         void onTagUser(@Nullable User user);
 
+        void onReply(User user, String message);
+
         void showReactionsPopup(@NonNull ReactionTypes type, @NonNull String login, @NonNull String repoId, long idOrNumber, @ReactionsProvider
                 .ReactionType int reactionType);
     }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/timeline/timeline/PullRequestTimelinePresenter.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/timeline/timeline/PullRequestTimelinePresenter.java
@@ -57,7 +57,7 @@ public class PullRequestTimelinePresenter extends BasePresenter<PullRequestTimel
                         if (item1.getItemId() == R.id.delete) {
                             getView().onShowDeleteMsg(item.getComment().getId(), false);
                         } else if (item1.getItemId() == R.id.reply) {
-                            getView().onTagUser(item.getComment().getUser());
+                            getView().onReply(item.getComment().getUser(), item.getComment().getBody());
                         } else if (item1.getItemId() == R.id.edit) {
                             getView().onEditComment(item.getComment());
                         } else if (item1.getItemId() == R.id.share) {
@@ -85,7 +85,7 @@ public class PullRequestTimelinePresenter extends BasePresenter<PullRequestTimel
                     popupMenu.setOnMenuItemClickListener(item1 -> {
                         if (getView() == null) return false;
                         if (item1.getItemId() == R.id.reply) {
-                            getView().onTagUser(item.getPullRequest().getUser());
+                            getView().onReply(item.getPullRequest().getUser(), item.getPullRequest().getBody());
                         } else if (item1.getItemId() == R.id.edit) {
                             Activity activity = ActivityHelper.getActivity(v.getContext());
                             if (activity == null) return false;
@@ -254,7 +254,7 @@ public class PullRequestTimelinePresenter extends BasePresenter<PullRequestTimel
                 if (item1.getItemId() == R.id.delete) {
                     getView().onShowDeleteMsg(comment.getId(), true);
                 } else if (item1.getItemId() == R.id.reply) {
-                    getView().onTagUser(comment.getUser());
+                    getView().onReply(comment.getUser(), comment.getBodyHtml());
                 } else if (item1.getItemId() == R.id.edit) {
                     getView().onEditReviewComment(comment);
                 } else if (item1.getItemId() == R.id.share) {

--- a/app/src/main/java/com/fastaccess/ui/modules/search/SearchActivity.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/SearchActivity.java
@@ -109,6 +109,7 @@ public class SearchActivity extends BaseActivity<SearchMvp.View, SearchPresenter
         if(getIntent().hasExtra("search")){
             searchEditText.setText(getIntent().getStringExtra("search"));
             onTextChange(searchEditText.getEditableText());
+            getPresenter().onSearchClicked(pager, searchEditText);
         }
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/search/SearchPresenter.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/SearchPresenter.java
@@ -51,10 +51,10 @@ class SearchPresenter extends BasePresenter<SearchMvp.View> implements SearchMvp
             SearchUsersFragment users = (SearchUsersFragment) viewPager.getAdapter().instantiateItem(viewPager, 1);
             SearchIssuesFragment issues = (SearchIssuesFragment) viewPager.getAdapter().instantiateItem(viewPager, 2);
             SearchCodeFragment code = (SearchCodeFragment) viewPager.getAdapter().instantiateItem(viewPager, 3);
-            repos.onSetSearchQuery(query);
-            users.onSetSearchQuery(query);
-            issues.onSetSearchQuery(query);
-            code.onSetSearchQuery(query, true);
+            repos.onQueueSearch(query);
+            users.onQueueSearch(query);
+            issues.onQueueSearch(query);
+            code.onQueueSearch(query, true);
             boolean noneMatch = Stream.of(hints).noneMatch(value -> value.getText().equalsIgnoreCase(query));
             if (noneMatch) {
                 SearchHistory searchHistory = new SearchHistory(query);

--- a/app/src/main/java/com/fastaccess/ui/modules/search/code/SearchCodeFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/code/SearchCodeFragment.java
@@ -134,6 +134,20 @@ public class SearchCodeFragment extends BaseFragment<SearchCodeMvp.View, SearchC
         }
     }
 
+    @Override
+    public void onQueueSearch(@NonNull String query) {
+        this.searchQuery = query;
+        if(getView()!=null)
+            onSetSearchQuery(query, false);
+    }
+
+    @Override
+    public void onQueueSearch(@NonNull String query, boolean showRepoName) {
+        this.searchQuery = query;
+        if(getView()!=null)
+            onSetSearchQuery(query, showRepoName);
+    }
+
     @NonNull @Override public OnLoadMore<String> getLoadMore() {
         if (onLoadMore == null) {
             onLoadMore = new OnLoadMore<>(getPresenter(), searchQuery);

--- a/app/src/main/java/com/fastaccess/ui/modules/search/code/SearchCodeMvp.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/code/SearchCodeMvp.java
@@ -25,6 +25,10 @@ interface SearchCodeMvp {
 
         void onSetSearchQuery(@NonNull String query, boolean showRepoName);
 
+        void onQueueSearch(@NonNull String query);
+
+        void onQueueSearch(@NonNull String query, boolean showRepoName);
+
         @NonNull OnLoadMore<String> getLoadMore();
 
         void onItemClicked(@NonNull SearchCodeModel item);

--- a/app/src/main/java/com/fastaccess/ui/modules/search/issues/SearchIssuesFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/issues/SearchIssuesFragment.java
@@ -130,6 +130,13 @@ public class SearchIssuesFragment extends BaseFragment<SearchIssuesMvp.View, Sea
         }
     }
 
+    @Override
+    public void onQueueSearch(@NonNull String query) {
+        this.searchQuery = query;
+        if(getView()!=null)
+            onSetSearchQuery(query);
+    }
+
     @NonNull @Override public OnLoadMore<String> getLoadMore() {
         if (onLoadMore == null) {
             onLoadMore = new OnLoadMore<>(getPresenter(), searchQuery);

--- a/app/src/main/java/com/fastaccess/ui/modules/search/issues/SearchIssuesMvp.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/issues/SearchIssuesMvp.java
@@ -25,6 +25,8 @@ interface SearchIssuesMvp {
 
         void onSetSearchQuery(@NonNull String query);
 
+        void onQueueSearch(@NonNull String query);
+
         @NonNull OnLoadMore<String> getLoadMore();
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/search/repos/SearchReposFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/repos/SearchReposFragment.java
@@ -131,6 +131,13 @@ public class SearchReposFragment extends BaseFragment<SearchReposMvp.View, Searc
         }
     }
 
+    @Override
+    public void onQueueSearch(@NonNull String query) {
+        this.searchQuery = query;
+        if(getView()!=null)
+            onSetSearchQuery(query);
+    }
+
     @NonNull @Override public OnLoadMore<String> getLoadMore() {
         if (onLoadMore == null) {
             onLoadMore = new OnLoadMore<>(getPresenter(), searchQuery);

--- a/app/src/main/java/com/fastaccess/ui/modules/search/repos/SearchReposMvp.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/repos/SearchReposMvp.java
@@ -25,6 +25,8 @@ interface SearchReposMvp {
 
         void onSetSearchQuery(@NonNull String query);
 
+        void onQueueSearch(@NonNull String query);
+
         @NonNull OnLoadMore<String> getLoadMore();
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/search/users/SearchUsersFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/users/SearchUsersFragment.java
@@ -129,6 +129,13 @@ public class SearchUsersFragment extends BaseFragment<SearchUsersMvp.View, Searc
         }
     }
 
+    @Override
+    public void onQueueSearch(@NonNull String query) {
+        this.searchQuery = query;
+        if(getView()!=null)
+            onSetSearchQuery(query);
+    }
+
     @NonNull @Override public OnLoadMore<String> getLoadMore() {
         if (onLoadMore == null) {
             onLoadMore = new OnLoadMore<>(getPresenter(), searchQuery);

--- a/app/src/main/java/com/fastaccess/ui/modules/search/users/SearchUsersMvp.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/users/SearchUsersMvp.java
@@ -25,6 +25,8 @@ interface SearchUsersMvp {
 
         void onSetSearchQuery(@NonNull String query);
 
+        void onQueueSearch(@NonNull String query);
+
         @NonNull OnLoadMore<String> getLoadMore();
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/settings/category/SettingsCategoryFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/settings/category/SettingsCategoryFragment.java
@@ -31,6 +31,7 @@ public class SettingsCategoryFragment extends PreferenceFragmentCompat implement
     private String app_lauguage;
 
     private Preference signatureVia;
+    private Preference notificationTime;
 
     @Override public void onAttach(Context context) {
         super.onAttach(context);
@@ -45,7 +46,11 @@ public class SettingsCategoryFragment extends PreferenceFragmentCompat implement
         switch (settings) {
             case 0:
                 addPreferencesFromResource(R.xml.notification_settings);
+                notificationTime = findPreference("notificationTime");
                 findPreference("notificationTime").setOnPreferenceChangeListener(this);
+                findPreference("notificationEnabled").setOnPreferenceChangeListener(this);
+                if(!PrefHelper.getBoolean("notificationEnabled"))
+                    getPreferenceScreen().removePreference(notificationTime);
                 break;
             case 1:
                 addPreferencesFromResource(R.xml.behaviour_settings);
@@ -87,7 +92,17 @@ public class SettingsCategoryFragment extends PreferenceFragmentCompat implement
     }
 
     @Override public boolean onPreferenceChange(Preference preference, Object newValue) {
-        if (preference.getKey().equalsIgnoreCase("notificationTime")) {
+        if (preference.getKey().equalsIgnoreCase("notificationEnabled")) {
+            if ((boolean)newValue) {
+                getPreferenceScreen().addPreference(notificationTime);
+                NotificationSchedulerJobTask.scheduleJob(getActivity().getApplicationContext(),
+                        PrefGetter.notificationDurationMillis(getActivity().getApplicationContext(), PrefHelper.getString("notificationTime")), true);
+            } else {
+                getPreferenceScreen().removePreference(notificationTime);
+                NotificationSchedulerJobTask.scheduleJob(getActivity().getApplicationContext(), -1, true);
+            }
+            return true;
+        } else if (preference.getKey().equalsIgnoreCase("notificationTime")) {
             NotificationSchedulerJobTask.scheduleJob(getActivity().getApplicationContext(),
                     PrefGetter.notificationDurationMillis(getActivity().getApplicationContext(), (String) newValue), true);
             return true;

--- a/app/src/main/java/com/fastaccess/ui/widgets/MentionsFontEditText.java
+++ b/app/src/main/java/com/fastaccess/ui/widgets/MentionsFontEditText.java
@@ -1,0 +1,41 @@
+package com.fastaccess.ui.widgets;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.util.AttributeSet;
+import android.view.inputmethod.EditorInfo;
+
+import com.fastaccess.helper.TypeFaceHelper;
+import com.linkedin.android.spyglass.tokenization.impl.WordTokenizer;
+import com.linkedin.android.spyglass.ui.MentionsEditText;
+import com.linkedin.android.spyglass.ui.RichEditorView;
+
+/**
+ * Created by JediB on 5/15/2017.
+ */
+
+public class MentionsFontEditText extends MentionsEditText{
+
+	public MentionsFontEditText(@NonNull Context context) {
+		super(context);
+		init();
+	}
+
+	public MentionsFontEditText(@NonNull Context context, AttributeSet attrs) {
+		super(context, attrs);
+		init();
+
+	}
+
+	public MentionsFontEditText(@NonNull Context context, AttributeSet attrs, int defStyleAttr) {
+		super(context, attrs, defStyleAttr);
+		init();
+	}
+
+	private void init() {
+		if (isInEditMode()) return;
+		setInputType(getInputType() | EditorInfo.IME_FLAG_NO_EXTRACT_UI | EditorInfo.IME_FLAG_NO_FULLSCREEN);
+		setImeOptions(getImeOptions() | EditorInfo.IME_FLAG_NO_FULLSCREEN);
+		TypeFaceHelper.applyTypeface(this);
+	}
+}

--- a/app/src/main/java/com/zzhoujay/markdown/MarkDown.java
+++ b/app/src/main/java/com/zzhoujay/markdown/MarkDown.java
@@ -1,7 +1,9 @@
 package com.zzhoujay.markdown;
 
 import android.text.Html;
+import android.text.Spannable;
 import android.text.Spanned;
+import android.text.style.CharacterStyle;
 import android.widget.TextView;
 
 import com.zzhoujay.markdown.parser.StyleBuilderImpl;

--- a/app/src/main/res/drawable/ic_ring_sound.xml
+++ b/app/src/main/res/drawable/ic_ring_sound.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M7.58,4.08L6.15,2.65C3.75,4.48 2.17,7.3 2.03,10.5h2c0.15,-2.65 1.51,-4.97 3.55,-6.42zM19.97,10.5h2c-0.15,-3.2 -1.73,-6.02 -4.12,-7.85l-1.42,1.43c2.02,1.45 3.39,3.77 3.54,6.42zM18,11c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2v-5zM12,22c0.14,0 0.27,-0.01 0.4,-0.04 0.65,-0.14 1.18,-0.58 1.44,-1.18 0.1,-0.24 0.15,-0.5 0.15,-0.78h-4c0.01,1.1 0.9,2 2.01,2z"
+        android:fillColor="?icon_color"/>
+</vector>

--- a/app/src/main/res/layouts/main_layouts/layout/editor_layout.xml
+++ b/app/src/main/res/layouts/main_layouts/layout/editor_layout.xml
@@ -26,6 +26,8 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
                 <com.fastaccess.ui.widgets.FontTextView
+                    android:id="@+id/replyQuoteText"
+                    android:textIsSelectable="true"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:alpha="0.6"

--- a/app/src/main/res/layouts/main_layouts/layout/editor_layout.xml
+++ b/app/src/main/res/layouts/main_layouts/layout/editor_layout.xml
@@ -39,7 +39,7 @@
                     android:background="?dividerColor"/>
             </LinearLayout>
 
-            <com.fastaccess.ui.widgets.FontEditText
+            <com.linkedin.android.spyglass.ui.MentionsEditText
                 android:id="@+id/editText"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -55,6 +55,12 @@
         </LinearLayout>
 
     </ScrollView>
+
+    <ListView
+        android:id="@+id/autocomplete"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:visibility="gone"/>
 
     <View
         android:layout_width="match_parent"

--- a/app/src/main/res/layouts/main_layouts/layout/editor_layout.xml
+++ b/app/src/main/res/layouts/main_layouts/layout/editor_layout.xml
@@ -15,18 +15,42 @@
         android:clipToPadding="false"
         android:fillViewport="true">
 
-        <com.fastaccess.ui.widgets.FontEditText
-            android:id="@+id/editText"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/transparent"
-            android:gravity="top|start"
-            android:hint="@string/type_here"
-            android:inputType="textMultiLine|textCapSentences"
-            android:minLines="5"
-            android:padding="@dimen/spacing_xs_large"
-            android:scrollbars="vertical"
-            tools:ignore="ScrollViewSize"/>
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:id="@+id/replyQuote"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+                <com.fastaccess.ui.widgets.FontTextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:alpha="0.6"
+                    android:padding="@dimen/spacing_xs_large"
+                    tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas quis sagittis purus. Cras pulvinar urna ut velit accumsan consectetur. Aenean mauris purus, rutrum eget luctus sit amet, efficitur vel mauris. Sed pulvinar nisl non ligula lacinia ultricies. Etiam quis purus sem. Morbi rutrum tristique ex sed commodo. Pellentesque volutpat laoreet urna et vestibulum. Vivamus id justo sed felis cursus venenatis id vitae felis. Praesent at condimentum erat. Vivamus vel est a dolor tincidunt porta. Mauris ut nisl tortor."/>
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="?dividerColor"/>
+            </LinearLayout>
+
+            <com.fastaccess.ui.widgets.FontEditText
+                android:id="@+id/editText"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/transparent"
+                android:gravity="top|start"
+                android:hint="@string/type_here"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="5"
+                android:padding="@dimen/spacing_xs_large"
+                android:scrollbars="vertical"
+                tools:ignore="ScrollViewSize"/>
+
+        </LinearLayout>
 
     </ScrollView>
 

--- a/app/src/main/res/layouts/main_layouts/layout/gists_activity_layout.xml
+++ b/app/src/main/res/layouts/main_layouts/layout/gists_activity_layout.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.DrawerLayout
+    android:id="@+id/drawer"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <android.support.design.widget.CoordinatorLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.design.widget.AppBarLayout
+            android:id="@+id/appbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="?android:toolbarStyle">
+
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?actionBarSize"
+                android:background="?colorPrimary"
+                android:theme="?android:toolbarStyle"
+                app:layout_scrollFlags="scroll|enterAlways"
+                app:popupTheme="?android:toolbarStyle"/>
+
+            <android.support.design.widget.TabLayout
+                android:id="@+id/tabs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?colorPrimary"
+                app:tabMode="fixed"
+                app:tabSelectedTextColor="?colorAccent"
+                app:tabTextColor="?android:textColorTertiary"/>
+        </android.support.design.widget.AppBarLayout>
+
+        <com.fastaccess.ui.widgets.ViewPagerView
+            android:id="@+id/gistsContainer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/scroll_behavior"/>
+
+        <android.support.design.widget.FloatingActionButton
+            android:id="@+id/fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="@dimen/fab_margin"
+            android:src="@drawable/ic_add"
+            android:tint="@color/white"
+            android:visibility="gone"
+            tools:visibility="visible"/>
+
+    </android.support.design.widget.CoordinatorLayout>
+
+    <include layout="@layout/nav_menu_layout"/>
+</android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layouts/main_layouts/layout/login_chooser_layout.xml
+++ b/app/src/main/res/layouts/main_layouts/layout/login_chooser_layout.xml
@@ -142,4 +142,28 @@
     </android.support.v4.widget.NestedScrollView>
 
 
+    <RelativeLayout
+        android:id="@+id/language_selector"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/material_grey_200"
+        android:layout_gravity="bottom">
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/white"
+            android:alpha="0.5"/>
+        <com.fastaccess.ui.widgets.FontTextView
+            android:id="@+id/language_selector_clicker"
+            android:background="?selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="@dimen/spacing_xs_large"
+            android:textAllCaps="true"
+            android:text="@string/choose_language_title"/>
+    </RelativeLayout>
+
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/drawer_menu.xml
+++ b/app/src/main/res/menu/drawer_menu.xml
@@ -46,11 +46,7 @@
         <item
             android:id="@+id/gists"
             android:icon="@drawable/ic_gists"
-            android:title="@string/public_gists"/>
-        <item
-            android:id="@+id/myGists"
-            android:icon="@drawable/ic_gists"
-            android:title="@string/my_gists"/>
+            android:title="@string/gists"/>
     </group>
 
     <group

--- a/app/src/main/res/menu/drawer_menu.xml
+++ b/app/src/main/res/menu/drawer_menu.xml
@@ -54,15 +54,6 @@
     </group>
 
     <group
-        android:id="@+id/fasthub_group"
-        android:checkableBehavior="single">
-        <item
-            android:id="@+id/fhRepo"
-            android:icon="@drawable/ic_github"
-            android:title="@string/app_name"/>
-    </group>
-
-    <group
         android:id="@+id/group_three"
         android:checkableBehavior="none">
         <item android:title="@string/action">
@@ -77,6 +68,11 @@
                     android:id="@+id/settings"
                     android:icon="@drawable/ic_settings"
                     android:title="@string/settings"/>
+
+                <item
+                    android:id="@+id/about"
+                    android:icon="@drawable/ic_info"
+                    android:title="@string/about"/>
 
                 <item
                     android:id="@+id/logout"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -388,6 +388,7 @@
     <string name="open_source_libs">Open source libraries</string>
     <string name="enable_notification_sound_summary">Enable notification sound once a notification is received.</string>
     <string name="enable_notification_sound_title">Enable notification sound</string>
+    <string name="enable_notification_title">Enable notification</string>
     <string name="login_with_personal_token">Login with personal token</string>
     <string name="personal_token">Personal Token</string>
     <string name="basic_login">Login via basic auth</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,7 +222,7 @@
     <string name="switch_branch">Switch branch</string>
     <string name="assignees">Assignees</string>
     <string name="edit">Edit</string>
-    <string name="edited">( edited )</string>
+    <string name="edited">\u2022 edited</string>
     <string name="update_issue">Update Issue</string>
     <string name="update_pull_request">Update Pull Request</string>
     <string name="no_milestones">No milestones</string>

--- a/app/src/main/res/xml/notification_settings.xml
+++ b/app/src/main/res/xml/notification_settings.xml
@@ -3,6 +3,12 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <SwitchPreference
+        android:defaultValue="true"
+        android:key="notificationEnabled"
+        android:icon="@drawable/ic_ring"
+        android:title="@string/enable_notification_title"/>
+
     <ListPreference
         android:defaultValue="@string/thirty_minutes"
         android:dialogTitle="@string/every"
@@ -23,7 +29,7 @@
     <SwitchPreference
         android:defaultValue="true"
         android:key="notificationSound"
-        android:icon="@drawable/ic_ring"
+        android:icon="@drawable/ic_ring_sound"
         android:summary="@string/enable_notification_sound_summary"
         android:title="@string/enable_notification_sound_title"/>
 


### PR DESCRIPTION
* Appeal issue #322 - FastHub is no longer in the DrawerLayout, but in the pinned repos.
* Appeal issue #405 - You can now disable notifications in it's own setting.
* Appeal issue #466 - If the system language is not supported, you can change it in the login page.
* Fix issue #475 - Feed now uses markdown, will be changed again.
* Appeal issue #487 - Issues and pull requests now display the repository it's in.
---
* On tag click now actually searches instead of opening search with the tag.
* "Private" tag is now grey, to make it more distinguishable.
* When you reply to a comment, it now shows you the comment in the editor.
* Gists are now one Activity with tabs instead of two separate sections.