### PR TITLE
Gradle: Move some variables to extra properties for code reuse

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,3 @@
-def taskRequests = getGradle().getStartParameter().getTaskRequests().toString()
-def isGms = taskRequests.contains("Gms") || taskRequests.contains("gms")
-
 apply plugin: 'com.android.application'
 if (isGms) {
     apply plugin: 'com.google.firebase.firebase-crash'

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,30 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext {
+        // See http://stackoverflow.com/questions/27372828/access-project-extra-properties-in-buildscript-closure
+        taskRequests = getGradle().getStartParameter().getTaskRequests().toString()
+        isGms = taskRequests.contains("Gms") || taskRequests.contains("gms")
+
+        butterKnifeVersion = '8.5.1'
+        icepickVersion = '3.2.0'
+        lombokVersion = '1.12.6'
+        supportVersion = "25.3.1"
+        firebase = "10.2.0"
+        thirtyinchVersion = '0.8.0'
+        retrofit = '2.1.0'
+        junitVersion = '4.12'
+        mockitoVersion = '1.10.19'
+        assertjVersion = '2.5.0'
+        espresseVersion = '2.2.2'
+    }
+
     repositories {
         jcenter()
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:2.4.0-alpha7'
-        def taskRequests = getGradle().getStartParameter().getTaskRequests().toString()
-        def isGms = taskRequests.contains("Gms") || taskRequests.contains("gms")
         if (isGms) {
             classpath 'com.google.gms:google-services:3.0.0'
             classpath 'com.google.firebase:firebase-plugins:1.0.5'
@@ -25,18 +42,4 @@ allprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-ext {
-    butterKnifeVersion = '8.5.1'
-    icepickVersion = '3.2.0'
-    lombokVersion = '1.12.6'
-    supportVersion = "25.3.1"
-    firebase = "10.2.0"
-    thirtyinchVersion = '0.8.0'
-    retrofit = '2.1.0'
-    junitVersion = '4.12'
-    mockitoVersion = '1.10.19'
-    assertjVersion = '2.5.0'
-    espresseVersion = '2.2.2'
 }


### PR DESCRIPTION
Also, move the "ext" closure inside the "buildscript" one so the extra
properties get evaluated when the "buildscript" closure is. For details
see

http://stackoverflow.com/questions/27372828/access-project-extra-properties-in-buildscript-closure