### PR TITLE
Legal Problem! Revert before it's too late!

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,6 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
-
-P.S: All Fasthub Pro features shouldn't be distributed or reimplemented in any fork or librated version. These features should only be available from FastHub original project & therefore it's prohibited for anyone to provide them for free or sell them for themselves. 
-
  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.


### PR DESCRIPTION
Hello FastHub Developers!
I was a contributor here before and back then we didn't grant our copyright to @k0shk0sh, sign a CLA or anything, so everyone contributed under the GPL producing respective GPL code(the cancerous nature of GPL as it is).
Recently @k0shk0sh made a mistake and changed the license file(with changes that are void according to GPL anyway) without asking explicit permission to do so from all contributors to the repo. 
The problem should be easily fixable by reverting this misstep, although if there were any new contributors who have sent code in the timeframe from 3rd September till now their code is licensed under the new text... which has void terms, so it's a much lesser problem.
Great that we got it before it's too late and people started suing each other