### PR TITLE
Fix for #876

### DIFF
--- a/app/src/main/java/com/fastaccess/provider/tasks/notification/NotificationSchedulerJobTask.java
+++ b/app/src/main/java/com/fastaccess/provider/tasks/notification/NotificationSchedulerJobTask.java
@@ -271,7 +271,7 @@ public class NotificationSchedulerJobTask extends JobService {
         NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         if (notificationManager != null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                NotificationChannel notificationChannel = new NotificationChannel(String.valueOf(id),
+                NotificationChannel notificationChannel = new NotificationChannel(notification.getChannelId(),
                         notification.getChannelId(), NotificationManager.IMPORTANCE_DEFAULT);
                 notificationChannel.setShowBadge(true);
                 notificationManager.createNotificationChannel(notificationChannel);


### PR DESCRIPTION
The notifications really can't work under Oreo, because you make the channel with some strange id, while providing the id as the name in the next argument. Maybe not the best fix, but I find this string to be as cool of an id as it is of a name. Definitely better than having no notifications at all.