### PR TITLE
Removed redundant code when stateLayout.hideProgress() is called with…

### DIFF
--- a/app/src/main/java/com/fastaccess/ui/modules/feeds/FeedsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/feeds/FeedsFragment.java
@@ -176,7 +176,6 @@ public class FeedsFragment extends BaseFragment<FeedsMvp.View, FeedsPresenter> i
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/filter/issues/fragment/FilterIssueFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/filter/issues/fragment/FilterIssueFragment.java
@@ -165,7 +165,6 @@ public class FilterIssueFragment extends BaseFragment<FilterIssuesMvp.View, Filt
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/gists/GistsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/gists/GistsFragment.java
@@ -125,7 +125,6 @@ public class GistsFragment extends BaseFragment<GistsMvp.View, GistsPresenter> i
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/gists/gist/comments/GistCommentsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/gists/gist/comments/GistCommentsFragment.java
@@ -265,7 +265,6 @@ public class GistCommentsFragment extends BaseFragment<GistCommentsMvp.View, Gis
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/main/issues/MyIssuesFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/main/issues/MyIssuesFragment.java
@@ -192,7 +192,6 @@ public class MyIssuesFragment extends BaseFragment<MyIssuesMvp.View, MyIssuesPre
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/main/orgs/OrgListDialogFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/main/orgs/OrgListDialogFragment.java
@@ -102,7 +102,6 @@ public class OrgListDialogFragment extends BaseDialogFragment<OrgListDialogMvp.V
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/main/pullrequests/MyPullRequestFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/main/pullrequests/MyPullRequestFragment.java
@@ -184,7 +184,6 @@ public class MyPullRequestFragment extends BaseFragment<MyPullRequestsMvp.View, 
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/notification/all/AllNotificationsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/notification/all/AllNotificationsFragment.java
@@ -139,7 +139,6 @@ public class AllNotificationsFragment extends BaseFragment<AllNotificationsMvp.V
 
     @Override public void hideProgress() {
         refresh.setRefreshing(false);
-        stateLayout.hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 
@@ -195,7 +194,6 @@ public class AllNotificationsFragment extends BaseFragment<AllNotificationsMvp.V
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/notification/unread/UnreadNotificationsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/notification/unread/UnreadNotificationsFragment.java
@@ -191,7 +191,6 @@ public class UnreadNotificationsFragment extends BaseFragment<UnreadNotification
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/profile/followers/ProfileFollowersFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/profile/followers/ProfileFollowersFragment.java
@@ -125,7 +125,6 @@ public class ProfileFollowersFragment extends BaseFragment<ProfileFollowersMvp.V
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/profile/following/ProfileFollowingFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/profile/following/ProfileFollowingFragment.java
@@ -125,7 +125,6 @@ public class ProfileFollowingFragment extends BaseFragment<ProfileFollowingMvp.V
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/profile/gists/ProfileGistsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/profile/gists/ProfileGistsFragment.java
@@ -149,7 +149,6 @@ public class ProfileGistsFragment extends BaseFragment<ProfileGistsMvp.View, Pro
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/profile/org/members/OrgMembersFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/profile/org/members/OrgMembersFragment.java
@@ -124,7 +124,6 @@ public class OrgMembersFragment extends BaseFragment<OrgMembersMvp.View, OrgMemb
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/profile/org/repos/OrgReposFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/profile/org/repos/OrgReposFragment.java
@@ -154,7 +154,6 @@ public class OrgReposFragment extends BaseFragment<OrgReposMvp.View, OrgReposPre
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/profile/org/teams/OrgTeamFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/profile/org/teams/OrgTeamFragment.java
@@ -124,7 +124,6 @@ public class OrgTeamFragment extends BaseFragment<OrgTeamMvp.View, OrgTeamPresen
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/profile/org/teams/details/members/TeamMembersFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/profile/org/teams/details/members/TeamMembersFragment.java
@@ -124,7 +124,6 @@ public class TeamMembersFragment extends BaseFragment<TeamMembersMvp.View, TeamM
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/profile/org/teams/details/repos/TeamReposFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/profile/org/teams/details/repos/TeamReposFragment.java
@@ -125,7 +125,6 @@ public class TeamReposFragment extends BaseFragment<TeamReposMvp.View, TeamRepos
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/profile/repos/ProfileReposFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/profile/repos/ProfileReposFragment.java
@@ -131,7 +131,6 @@ public class ProfileReposFragment extends BaseFragment<ProfileReposMvp.View, Pro
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/profile/starred/ProfileStarredFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/profile/starred/ProfileStarredFragment.java
@@ -147,7 +147,6 @@ public class ProfileStarredFragment extends BaseFragment<ProfileStarredMvp.View,
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/RepoCommitsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/RepoCommitsFragment.java
@@ -183,7 +183,6 @@ public class RepoCommitsFragment extends BaseFragment<RepoCommitsMvp.View, RepoC
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/details/comments/CommitCommentsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/code/commit/details/comments/CommitCommentsFragment.java
@@ -297,7 +297,6 @@ public class CommitCommentsFragment extends BaseFragment<CommitCommentsMvp.View,
     }
 
     @Override public void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/code/contributors/RepoContributorsFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/code/contributors/RepoContributorsFragment.java
@@ -130,7 +130,6 @@ public class RepoContributorsFragment extends BaseFragment<RepoContributorsMvp.V
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/code/files/RepoFilesFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/code/files/RepoFilesFragment.java
@@ -235,7 +235,6 @@ public class RepoFilesFragment extends BaseFragment<RepoFilesMvp.View, RepoFiles
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/code/prettifier/ViewerFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/code/prettifier/ViewerFragment.java
@@ -120,7 +120,6 @@ public class ViewerFragment extends BaseFragment<ViewerMvp.View, ViewerPresenter
 
     @Override public void hideProgress() {
         loader.setVisibility(View.GONE);
-        stateLayout.hideProgress();
         if (!getPresenter().isImage()) stateLayout.showReload(getPresenter().downloadedStream() == null ? 0 : 1);
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/code/releases/RepoReleasesFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/code/releases/RepoReleasesFragment.java
@@ -187,7 +187,6 @@ public class RepoReleasesFragment extends BaseFragment<RepoReleasesMvp.View, Rep
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/extras/assignees/AssigneesDialogFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/extras/assignees/AssigneesDialogFragment.java
@@ -156,7 +156,6 @@ public class AssigneesDialogFragment extends BaseDialogFragment<AssigneesMvp.Vie
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/extras/branches/BranchesFragment.kt
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/extras/branches/BranchesFragment.kt
@@ -87,7 +87,6 @@ class BranchesFragment : BaseFragment<BranchesMvp.View, BranchesPresenter>(), Br
 
     override fun hideProgress() {
         refresh.isRefreshing = false
-        stateLayout.hideProgress()
         stateLayout.showReload(adapter.itemCount)
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/extras/labels/LabelsDialogFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/extras/labels/LabelsDialogFragment.java
@@ -184,7 +184,6 @@ public class LabelsDialogFragment extends BaseDialogFragment<LabelsMvp.View, Lab
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/extras/milestone/MilestoneDialogFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/extras/milestone/MilestoneDialogFragment.java
@@ -147,7 +147,6 @@ public class MilestoneDialogFragment extends BaseFragment<MilestoneMvp.View, Mil
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/extras/misc/RepoMiscDialogFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/extras/misc/RepoMiscDialogFragment.java
@@ -139,7 +139,6 @@ public class RepoMiscDialogFragment extends BaseDialogFragment<RepoMiscMVp.View,
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/RepoClosedIssuesFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/RepoClosedIssuesFragment.java
@@ -203,7 +203,6 @@ public class RepoClosedIssuesFragment extends BaseFragment<RepoIssuesMvp.View, R
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/RepoOpenedIssuesFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/RepoOpenedIssuesFragment.java
@@ -213,7 +213,6 @@ public class RepoOpenedIssuesFragment extends BaseFragment<RepoIssuesMvp.View, R
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelineFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/issues/issue/details/timeline/IssueTimelineFragment.java
@@ -367,7 +367,6 @@ public class IssueTimelineFragment extends BaseFragment<IssueTimelineMvp.View, I
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/projects/columns/ProjectColumnFragment.kt
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/projects/columns/ProjectColumnFragment.kt
@@ -234,7 +234,6 @@ class ProjectColumnFragment : BaseFragment<ProjectColumnMvp.View, ProjectColumnP
     }
 
     private fun showReload() {
-        hideProgress()
         stateLayout.showReload(adapter.itemCount)
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/projects/list/RepoProjectFragment.kt
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/projects/list/RepoProjectFragment.kt
@@ -127,7 +127,6 @@ class RepoProjectFragment : BaseFragment<RepoProjectMvp.View, RepoProjectPresent
     }
 
     private fun showReload() {
-        hideProgress()
         stateLayout.showReload(adapter.itemCount)
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/RepoPullRequestFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/RepoPullRequestFragment.java
@@ -196,7 +196,6 @@ public class RepoPullRequestFragment extends BaseFragment<RepoPullRequestMvp.Vie
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/files/PullRequestFilesFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/files/PullRequestFilesFragment.java
@@ -257,7 +257,6 @@ public class PullRequestFilesFragment extends BaseFragment<PullRequestFilesMvp.V
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/timeline/timeline/PullRequestTimelineFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/pull_requests/pull_request/details/timeline/timeline/PullRequestTimelineFragment.java
@@ -424,7 +424,6 @@ public class PullRequestTimelineFragment extends BaseFragment<PullRequestTimelin
     }
 
     @Override public void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 

--- a/app/src/main/java/com/fastaccess/ui/modules/repos/reactions/ReactionsDialogFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/repos/reactions/ReactionsDialogFragment.java
@@ -128,7 +128,6 @@ public class ReactionsDialogFragment extends BaseDialogFragment<ReactionsDialogM
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/search/code/SearchCodeFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/code/SearchCodeFragment.java
@@ -182,7 +182,6 @@ public class SearchCodeFragment extends BaseFragment<SearchCodeMvp.View, SearchC
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/search/issues/SearchIssuesFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/issues/SearchIssuesFragment.java
@@ -169,7 +169,6 @@ public class SearchIssuesFragment extends BaseFragment<SearchIssuesMvp.View, Sea
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/search/repos/SearchReposFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/repos/SearchReposFragment.java
@@ -165,7 +165,6 @@ public class SearchReposFragment extends BaseFragment<SearchReposMvp.View, Searc
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/search/users/SearchUsersFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/search/users/SearchUsersFragment.java
@@ -163,7 +163,6 @@ public class SearchUsersFragment extends BaseFragment<SearchUsersMvp.View, Searc
     }
 
     private void showReload() {
-        hideProgress();
         stateLayout.showReload(adapter.getItemCount());
     }
 }

--- a/app/src/main/java/com/fastaccess/ui/modules/trending/fragment/TrendingFragment.kt
+++ b/app/src/main/java/com/fastaccess/ui/modules/trending/fragment/TrendingFragment.kt
@@ -61,7 +61,6 @@ class TrendingFragment : BaseFragment<TrendingFragmentMvp.View, TrendingFragment
 
     override fun hideProgress() {
         refresh.isRefreshing = false
-        stateLayout.hideProgress()
         stateLayout.showReload(adapter.itemCount)
     }
 


### PR DESCRIPTION
… stateLayout.showReload(). showReload() calls hideProgress() inside it, so there is no need for the outside call.