### PR TITLE
Reduce the boilerplate in making a Kotlin class parcelable

### DIFF
--- a/app/src/main/java/com/fastaccess/data/dao/EditRepoFileModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/EditRepoFileModel.kt
@@ -2,6 +2,7 @@ package com.fastaccess.data.dao
 
 import android.os.Parcel
 import android.os.Parcelable
+import com.fastaccess.helper.KParcelable
 
 /**
  * Created by Hashemsergani on 01/09/2017.
@@ -13,7 +14,7 @@ data class EditRepoFileModel(val login: String,
                              val sha: String?,
                              val contentUrl: String?,
                              val fileName: String?,
-                             val isEdit: Boolean) : Parcelable {
+                             val isEdit: Boolean) : KParcelable {
     constructor(parcel: Parcel) : this(
             parcel.readString(),
             parcel.readString(),
@@ -33,10 +34,6 @@ data class EditRepoFileModel(val login: String,
         parcel.writeString(contentUrl)
         parcel.writeString(fileName)
         parcel.writeByte(if (isEdit) 1 else 0)
-    }
-
-    override fun describeContents(): Int {
-        return 0
     }
 
     companion object CREATOR : Parcelable.Creator<EditRepoFileModel> {

--- a/app/src/main/java/com/fastaccess/data/dao/EditRepoFileModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/EditRepoFileModel.kt
@@ -25,15 +25,15 @@ data class EditRepoFileModel(val login: String,
             parcel.readString(),
             parcel.readByte() != 0.toByte())
 
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeString(login)
-        parcel.writeString(repoId)
-        parcel.writeString(path)
-        parcel.writeString(ref)
-        parcel.writeString(sha)
-        parcel.writeString(contentUrl)
-        parcel.writeString(fileName)
-        parcel.writeByte(if (isEdit) 1 else 0)
+    override fun writeToParcel(dest: Parcel, flags: Int) = with(dest) {
+        writeString(login)
+        writeString(repoId)
+        writeString(path)
+        writeString(ref)
+        writeString(sha)
+        writeString(contentUrl)
+        writeString(fileName)
+        writeByte(if (isEdit) 1 else 0)
     }
 
     companion object {

--- a/app/src/main/java/com/fastaccess/data/dao/EditRepoFileModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/EditRepoFileModel.kt
@@ -1,8 +1,8 @@
 package com.fastaccess.data.dao
 
 import android.os.Parcel
-import android.os.Parcelable
 import com.fastaccess.helper.KParcelable
+import com.fastaccess.helper.parcelableCreator
 
 /**
  * Created by Hashemsergani on 01/09/2017.
@@ -36,13 +36,7 @@ data class EditRepoFileModel(val login: String,
         parcel.writeByte(if (isEdit) 1 else 0)
     }
 
-    companion object CREATOR : Parcelable.Creator<EditRepoFileModel> {
-        override fun createFromParcel(parcel: Parcel): EditRepoFileModel {
-            return EditRepoFileModel(parcel)
-        }
-
-        override fun newArray(size: Int): Array<EditRepoFileModel?> {
-            return arrayOfNulls(size)
-        }
+    companion object {
+        @JvmField val CREATOR = parcelableCreator(::EditRepoFileModel)
     }
 }

--- a/app/src/main/java/com/fastaccess/data/dao/EditRepoFileModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/EditRepoFileModel.kt
@@ -3,6 +3,8 @@ package com.fastaccess.data.dao
 import android.os.Parcel
 import com.fastaccess.helper.KParcelable
 import com.fastaccess.helper.parcelableCreator
+import com.fastaccess.helper.readBoolean
+import com.fastaccess.helper.writeBoolean
 
 /**
  * Created by Hashemsergani on 01/09/2017.
@@ -23,7 +25,7 @@ data class EditRepoFileModel(val login: String,
             parcel.readString(),
             parcel.readString(),
             parcel.readString(),
-            parcel.readByte() != 0.toByte())
+            parcel.readBoolean())
 
     override fun writeToParcel(dest: Parcel, flags: Int) = with(dest) {
         writeString(login)
@@ -33,7 +35,7 @@ data class EditRepoFileModel(val login: String,
         writeString(sha)
         writeString(contentUrl)
         writeString(fileName)
-        writeByte(if (isEdit) 1 else 0)
+        writeBoolean(isEdit)
     }
 
     companion object {

--- a/app/src/main/java/com/fastaccess/data/dao/EditRepoFileModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/EditRepoFileModel.kt
@@ -1,7 +1,7 @@
 package com.fastaccess.data.dao
 
 import android.os.Parcel
-import com.fastaccess.helper.KParcelable
+import com.fastaccess.helper.KotlinParcelable
 import com.fastaccess.helper.parcelableCreator
 import com.fastaccess.helper.readBoolean
 import com.fastaccess.helper.writeBoolean
@@ -16,7 +16,7 @@ data class EditRepoFileModel(val login: String,
                              val sha: String?,
                              val contentUrl: String?,
                              val fileName: String?,
-                             val isEdit: Boolean) : KParcelable {
+                             val isEdit: Boolean) : KotlinParcelable {
     constructor(parcel: Parcel) : this(
             parcel.readString(),
             parcel.readString(),

--- a/app/src/main/java/com/fastaccess/data/dao/TrendingModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/TrendingModel.kt
@@ -1,8 +1,8 @@
 package com.fastaccess.data.dao
 
 import android.os.Parcel
-import android.os.Parcelable
 import com.fastaccess.helper.KParcelable
+import com.fastaccess.helper.parcelableCreator
 
 data class TrendingModel(
         val title: String? = null,
@@ -12,10 +12,7 @@ data class TrendingModel(
         val forks: String? = null,
         val todayStars: String? = null) : KParcelable {
     companion object {
-        @JvmField val CREATOR: Parcelable.Creator<TrendingModel> = object : Parcelable.Creator<TrendingModel> {
-            override fun createFromParcel(source: Parcel): TrendingModel = TrendingModel(source)
-            override fun newArray(size: Int): Array<TrendingModel?> = arrayOfNulls(size)
-        }
+        @JvmField val CREATOR = parcelableCreator(::TrendingModel)
     }
 
     constructor(source: Parcel) : this(

--- a/app/src/main/java/com/fastaccess/data/dao/TrendingModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/TrendingModel.kt
@@ -1,7 +1,7 @@
 package com.fastaccess.data.dao
 
 import android.os.Parcel
-import com.fastaccess.helper.KParcelable
+import com.fastaccess.helper.KotlinParcelable
 import com.fastaccess.helper.parcelableCreator
 
 data class TrendingModel(
@@ -10,7 +10,7 @@ data class TrendingModel(
         val language: String? = null,
         val stars: String? = null,
         val forks: String? = null,
-        val todayStars: String? = null) : KParcelable {
+        val todayStars: String? = null) : KotlinParcelable {
     companion object {
         @JvmField val CREATOR = parcelableCreator(::TrendingModel)
     }

--- a/app/src/main/java/com/fastaccess/data/dao/TrendingModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/TrendingModel.kt
@@ -2,6 +2,7 @@ package com.fastaccess.data.dao
 
 import android.os.Parcel
 import android.os.Parcelable
+import com.fastaccess.helper.KParcelable
 
 data class TrendingModel(
         val title: String? = null,
@@ -9,7 +10,7 @@ data class TrendingModel(
         val language: String? = null,
         val stars: String? = null,
         val forks: String? = null,
-        val todayStars: String? = null) : Parcelable {
+        val todayStars: String? = null) : KParcelable {
     companion object {
         @JvmField val CREATOR: Parcelable.Creator<TrendingModel> = object : Parcelable.Creator<TrendingModel> {
             override fun createFromParcel(source: Parcel): TrendingModel = TrendingModel(source)
@@ -25,8 +26,6 @@ data class TrendingModel(
             source.readString(),
             source.readString()
     )
-
-    override fun describeContents() = 0
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
         dest.writeString(title)

--- a/app/src/main/java/com/fastaccess/data/dao/TrendingModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/TrendingModel.kt
@@ -24,12 +24,12 @@ data class TrendingModel(
             source.readString()
     )
 
-    override fun writeToParcel(dest: Parcel, flags: Int) {
-        dest.writeString(title)
-        dest.writeString(description)
-        dest.writeString(language)
-        dest.writeString(stars)
-        dest.writeString(forks)
-        dest.writeString(todayStars)
+    override fun writeToParcel(dest: Parcel, flags: Int) = with(dest) {
+        writeString(title)
+        writeString(description)
+        writeString(language)
+        writeString(stars)
+        writeString(forks)
+        writeString(todayStars)
     }
 }

--- a/app/src/main/java/com/fastaccess/data/dao/wiki/WikiContentModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/wiki/WikiContentModel.kt
@@ -2,12 +2,13 @@ package com.fastaccess.data.dao.wiki
 
 import android.os.Parcel
 import android.os.Parcelable
+import com.fastaccess.helper.KParcelable
 
 /**
  * Created by Kosh on 13 Jun 2017, 8:06 PM
  */
 data class WikiContentModel(val content: String? = null, private val footer: String? = null,
-                            val sidebar: ArrayList<WikiSideBarModel>) : Parcelable {
+                            val sidebar: ArrayList<WikiSideBarModel>) : KParcelable {
     companion object {
         @JvmField val CREATOR: Parcelable.Creator<WikiContentModel> = object : Parcelable.Creator<WikiContentModel> {
             override fun createFromParcel(source: Parcel): WikiContentModel = WikiContentModel(source)
@@ -20,8 +21,6 @@ data class WikiContentModel(val content: String? = null, private val footer: Str
             source.readString(),
             source.createTypedArrayList(WikiSideBarModel.CREATOR)
     )
-
-    override fun describeContents() = 0
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
         dest.writeString(content)

--- a/app/src/main/java/com/fastaccess/data/dao/wiki/WikiContentModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/wiki/WikiContentModel.kt
@@ -1,8 +1,8 @@
 package com.fastaccess.data.dao.wiki
 
 import android.os.Parcel
-import android.os.Parcelable
 import com.fastaccess.helper.KParcelable
+import com.fastaccess.helper.parcelableCreator
 
 /**
  * Created by Kosh on 13 Jun 2017, 8:06 PM
@@ -10,10 +10,7 @@ import com.fastaccess.helper.KParcelable
 data class WikiContentModel(val content: String? = null, private val footer: String? = null,
                             val sidebar: ArrayList<WikiSideBarModel>) : KParcelable {
     companion object {
-        @JvmField val CREATOR: Parcelable.Creator<WikiContentModel> = object : Parcelable.Creator<WikiContentModel> {
-            override fun createFromParcel(source: Parcel): WikiContentModel = WikiContentModel(source)
-            override fun newArray(size: Int): Array<WikiContentModel?> = arrayOfNulls(size)
-        }
+        @JvmField val CREATOR = parcelableCreator(::WikiContentModel)
     }
 
     constructor(source: Parcel) : this(

--- a/app/src/main/java/com/fastaccess/data/dao/wiki/WikiContentModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/wiki/WikiContentModel.kt
@@ -1,14 +1,14 @@
 package com.fastaccess.data.dao.wiki
 
 import android.os.Parcel
-import com.fastaccess.helper.KParcelable
+import com.fastaccess.helper.KotlinParcelable
 import com.fastaccess.helper.parcelableCreator
 
 /**
  * Created by Kosh on 13 Jun 2017, 8:06 PM
  */
 data class WikiContentModel(val content: String? = null, private val footer: String? = null,
-                            val sidebar: ArrayList<WikiSideBarModel>) : KParcelable {
+                            val sidebar: ArrayList<WikiSideBarModel>) : KotlinParcelable {
     companion object {
         @JvmField val CREATOR = parcelableCreator(::WikiContentModel)
     }

--- a/app/src/main/java/com/fastaccess/data/dao/wiki/WikiContentModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/wiki/WikiContentModel.kt
@@ -19,9 +19,9 @@ data class WikiContentModel(val content: String? = null, private val footer: Str
             source.createTypedArrayList(WikiSideBarModel.CREATOR)
     )
 
-    override fun writeToParcel(dest: Parcel, flags: Int) {
-        dest.writeString(content)
-        dest.writeString(footer)
-        dest.writeTypedList(sidebar)
+    override fun writeToParcel(dest: Parcel, flags: Int) = with(dest) {
+        writeString(content)
+        writeString(footer)
+        writeTypedList(sidebar)
     }
 }

--- a/app/src/main/java/com/fastaccess/data/dao/wiki/WikiSideBarModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/wiki/WikiSideBarModel.kt
@@ -17,8 +17,8 @@ data class WikiSideBarModel(val title: String? = null, val link: String? = null)
             source.readString()
     )
 
-    override fun writeToParcel(dest: Parcel, flags: Int) {
-        dest.writeString(title)
-        dest.writeString(link)
+    override fun writeToParcel(dest: Parcel, flags: Int) = with(dest) {
+        writeString(title)
+        writeString(link)
     }
 }

--- a/app/src/main/java/com/fastaccess/data/dao/wiki/WikiSideBarModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/wiki/WikiSideBarModel.kt
@@ -1,13 +1,13 @@
 package com.fastaccess.data.dao.wiki
 
 import android.os.Parcel
-import com.fastaccess.helper.KParcelable
+import com.fastaccess.helper.KotlinParcelable
 import com.fastaccess.helper.parcelableCreator
 
 /**
  * Created by Kosh on 13 Jun 2017, 8:03 PM
  */
-data class WikiSideBarModel(val title: String? = null, val link: String? = null) : KParcelable {
+data class WikiSideBarModel(val title: String? = null, val link: String? = null) : KotlinParcelable {
     companion object {
         @JvmField val CREATOR = parcelableCreator(::WikiSideBarModel)
     }

--- a/app/src/main/java/com/fastaccess/data/dao/wiki/WikiSideBarModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/wiki/WikiSideBarModel.kt
@@ -2,11 +2,12 @@ package com.fastaccess.data.dao.wiki
 
 import android.os.Parcel
 import android.os.Parcelable
+import com.fastaccess.helper.KParcelable
 
 /**
  * Created by Kosh on 13 Jun 2017, 8:03 PM
  */
-data class WikiSideBarModel(val title: String? = null, val link: String? = null) : Parcelable {
+data class WikiSideBarModel(val title: String? = null, val link: String? = null) : KParcelable {
     companion object {
         @JvmField val CREATOR: Parcelable.Creator<WikiSideBarModel> = object : Parcelable.Creator<WikiSideBarModel> {
             override fun createFromParcel(source: Parcel): WikiSideBarModel = WikiSideBarModel(source)
@@ -18,8 +19,6 @@ data class WikiSideBarModel(val title: String? = null, val link: String? = null)
             source.readString(),
             source.readString()
     )
-
-    override fun describeContents() = 0
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
         dest.writeString(title)

--- a/app/src/main/java/com/fastaccess/data/dao/wiki/WikiSideBarModel.kt
+++ b/app/src/main/java/com/fastaccess/data/dao/wiki/WikiSideBarModel.kt
@@ -1,18 +1,15 @@
 package com.fastaccess.data.dao.wiki
 
 import android.os.Parcel
-import android.os.Parcelable
 import com.fastaccess.helper.KParcelable
+import com.fastaccess.helper.parcelableCreator
 
 /**
  * Created by Kosh on 13 Jun 2017, 8:03 PM
  */
 data class WikiSideBarModel(val title: String? = null, val link: String? = null) : KParcelable {
     companion object {
-        @JvmField val CREATOR: Parcelable.Creator<WikiSideBarModel> = object : Parcelable.Creator<WikiSideBarModel> {
-            override fun createFromParcel(source: Parcel): WikiSideBarModel = WikiSideBarModel(source)
-            override fun newArray(size: Int): Array<WikiSideBarModel?> = arrayOfNulls(size)
-        }
+        @JvmField val CREATOR = parcelableCreator(::WikiSideBarModel)
     }
 
     constructor(source: Parcel) : this(

--- a/app/src/main/java/com/fastaccess/helper/ParcelableHelper.kt
+++ b/app/src/main/java/com/fastaccess/helper/ParcelableHelper.kt
@@ -12,3 +12,7 @@ inline fun <reified T> parcelableCreator(crossinline create: (Parcel) -> T) = ob
     override fun createFromParcel(source: Parcel) = create(source)
     override fun newArray(size: Int) = arrayOfNulls<T>(size)
 }
+
+fun Parcel.readBoolean() = readInt() != 0
+
+fun Parcel.writeBoolean(value: Boolean) = writeInt(if (value) 1 else 0)

--- a/app/src/main/java/com/fastaccess/helper/ParcelableHelper.kt
+++ b/app/src/main/java/com/fastaccess/helper/ParcelableHelper.kt
@@ -7,3 +7,8 @@ interface KParcelable : Parcelable {
     override fun describeContents() = 0
     override fun writeToParcel(dest: Parcel, flags: Int)
 }
+
+inline fun <reified T> parcelableCreator(crossinline create: (Parcel) -> T) = object : Parcelable.Creator<T> {
+    override fun createFromParcel(source: Parcel) = create(source)
+    override fun newArray(size: Int) = arrayOfNulls<T>(size)
+}

--- a/app/src/main/java/com/fastaccess/helper/ParcelableHelper.kt
+++ b/app/src/main/java/com/fastaccess/helper/ParcelableHelper.kt
@@ -1,0 +1,7 @@
+package com.fastaccess.helper
+
+import android.os.Parcelable
+
+interface KParcelable : Parcelable {
+    override fun describeContents() = 0
+}

--- a/app/src/main/java/com/fastaccess/helper/ParcelableHelper.kt
+++ b/app/src/main/java/com/fastaccess/helper/ParcelableHelper.kt
@@ -1,7 +1,9 @@
 package com.fastaccess.helper
 
+import android.os.Parcel
 import android.os.Parcelable
 
 interface KParcelable : Parcelable {
     override fun describeContents() = 0
+    override fun writeToParcel(dest: Parcel, flags: Int)
 }

--- a/app/src/main/java/com/fastaccess/helper/ParcelableHelper.kt
+++ b/app/src/main/java/com/fastaccess/helper/ParcelableHelper.kt
@@ -3,7 +3,7 @@ package com.fastaccess.helper
 import android.os.Parcel
 import android.os.Parcelable
 
-interface KParcelable : Parcelable {
+interface KotlinParcelable : Parcelable {
     override fun describeContents() = 0
     override fun writeToParcel(dest: Parcel, flags: Int)
 }


### PR DESCRIPTION
This reduces some of the ceremony required to implement Parcelable in a Kotlin class. The commits line up with [this](https://medium.com/@BladeCoder/reducing-parcelable-boilerplate-code-using-kotlin-741c3124a49a) article.

`KParcelable` (short for "Kotlin Parcelable") isn't a great `interface` name, but I couldn't think of a better one tbh. I think for the time being it's OK as the distinction between a Parcelable interface for Kotlin and a Parcelable interface for Java is made, but if you can think of a better, more general name for the interface, just shoot a comment.

Side note: I see that the LOC hasn't changed much, but this is due to the fixed LOC overhead of `ParcelableHelper`. As more models are written in Kotlin, the benefits of this PR will be more noticeable in terms of reductions in LOC.