### PR TITLE
Code color palette will show saved theme

### DIFF
--- a/app/src/main/java/com/fastaccess/ui/modules/theme/code/ThemeCodeActivity.kt
+++ b/app/src/main/java/com/fastaccess/ui/modules/theme/code/ThemeCodeActivity.kt
@@ -45,6 +45,8 @@ class ThemeCodeActivity : BaseActivity<ThemeCodeMvp.View, ThemeCodePresenter>(),
     override fun onInitAdapter(list: List<String>) {
         val adapter = SpinnerAdapter<String>(this, list)
         spinner.adapter = adapter
+        var theme_position = list.indexOf(PrefGetter.getCodeTheme())
+        spinner.setSelection(theme_position)
     }
 
     @OnItemSelected(R.id.themesList) fun onItemSelect() {


### PR DESCRIPTION
When opening `Code color palette` activity from `Settings`, the default theme that opens is `prettify.css` regardless of what user has saved. 

Now, it will show the theme already saved by user. 
