### PR TITLE
Fix: getLayoutManager() on DynamicRecyclerView is never GridLayoutManager

### DIFF
--- a/app/src/main/java/com/fastaccess/ui/widgets/recyclerview/DynamicRecyclerView.java
+++ b/app/src/main/java/com/fastaccess/ui/widgets/recyclerview/DynamicRecyclerView.java
@@ -149,10 +149,10 @@ public class DynamicRecyclerView extends RecyclerView {
 
     private boolean canAddDivider() {
         if (getLayoutManager() != null) {
-            if (getLayoutManager() instanceof LinearLayoutManager) {
-                return true;
-            } else if (getLayoutManager() instanceof GridLayoutManager) {
+            if (getLayoutManager() instanceof GridLayoutManager) {
                 return ((GridLayoutManager) getLayoutManager()).getSpanCount() == 1;
+            } else if (getLayoutManager() instanceof LinearLayoutManager) {
+                return true;
             } else if (getLayoutManager() instanceof StaggeredGridLayoutManager) {
                 return ((StaggeredGridLayoutManager) getLayoutManager()).getSpanCount() == 1;
             }


### PR DESCRIPTION
since GridLayoutManager is a LinearLayoutManager and LinearLayoutManager is always called before it.

This was happening here:
https://github.com/k0shk0sh/FastHub/blob/a2ac3d74e849f311c05facc177cf1b6e03434b39/app/src/main/java/com/fastaccess/ui/widgets/recyclerview/DynamicRecyclerView.java#L154

And is the same issue I reported before as: #1434

Yes, I double checked, this was the last one on all the project.