### PR TITLE
Fix early quote marks (#1578)

### DIFF
--- a/app/src/main/java/com/fastaccess/provider/timeline/handler/QuoteHandler.java
+++ b/app/src/main/java/com/fastaccess/provider/timeline/handler/QuoteHandler.java
@@ -19,9 +19,8 @@ import lombok.AllArgsConstructor;
 
     @ColorInt private int color;
 
+    @Override
     public void handleTagNode(TagNode node, SpannableStringBuilder builder, int start, int end) {
-        builder.append("\n");
-        builder.setSpan(new MarkDownQuoteSpan(color), (start > builder.length() - 1) ? start + 1 : start, builder.length() - 1, 33);
-        builder.append("\n");
+        builder.setSpan(new MarkDownQuoteSpan(color), start + 1, builder.length(), 33);
     }
 }


### PR DESCRIPTION
I tried to solve #1578.
If appending a new line after setting quote marks of a first quote, the calculations for a second quote are wrong. Maybe it's a bug of `TagNodeHandler`, which doesn't update start value of next quote. Kind of strange.

Anyway, I don't think extra lines are needed as they already appear in string (before and after quotes).