### PR TITLE
fixed AboutLibrary toolbar title

### DIFF
--- a/app/src/main/java/com/fastaccess/ui/modules/about/FastHubAboutActivity.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/about/FastHubAboutActivity.java
@@ -154,6 +154,7 @@ public class FastHubAboutActivity extends MaterialAboutActivity {
                         .setOnClickAction(() -> new LibsBuilder()
                                 .withActivityStyle(AppHelper.isNightMode(getResources()) ? Libs.ActivityStyle.DARK : Libs.ActivityStyle.LIGHT)
                                 .withAutoDetect(true)
+                                .withActivityTitle(this.getResources().getString(R.string.open_source_libs))
                                 .withAboutIconShown(true)
                                 .withAboutVersionShown(true)
                                 .start(this))


### PR DESCRIPTION
In About section, Open source libraries's activity toolbar title was missing