### PR TITLE
fix: add logic for replace html escaped symbols in uri string.

### DIFF
--- a/app/src/main/java/com/fastaccess/provider/scheme/SchemeParser.java
+++ b/app/src/main/java/com/fastaccess/provider/scheme/SchemeParser.java
@@ -69,9 +69,13 @@ public class SchemeParser {
 
     public static void launchUri(@NonNull Context context, @NonNull Uri data, boolean showRepoBtn, boolean newDocument) {
         Logger.e(data);
-        Intent intent = convert(context, data, showRepoBtn);
+        Uri uri = Uri.parse(data.toString()
+                .replace("&amp;", "&")
+                .replace("&lt", "<")
+                .replace("&gt", ">"));
+        Intent intent = convert(context, uri, showRepoBtn);
         if (intent != null) {
-            intent.putExtra(BundleConstant.SCHEME_URL, data.toString());
+            intent.putExtra(BundleConstant.SCHEME_URL, uri.toString());
             if (newDocument) {
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT | Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
             }
@@ -82,9 +86,9 @@ public class SchemeParser {
         } else {
             Activity activity = ActivityHelper.getActivity(context);
             if (activity != null) {
-                ActivityHelper.startCustomTab(activity, data);
+                ActivityHelper.startCustomTab(activity, uri);
             } else {
-                ActivityHelper.openChooser(context, data);
+                ActivityHelper.openChooser(context, uri);
             }
         }
     }


### PR DESCRIPTION
Hi folks. 
I investigated the problem with issue https://github.com/k0shk0sh/FastHub/issues/2890
The problem happens when extract URL from Html node, where & present as &amp  (by 'net.sourceforge.htmlcleaner:htmlcleaner:2.2'). It normal display in TextView. Uri.parse() not converted this escaped symbol and try open page with it. 
I not sure, this solution is best, but it resolves the problem.
