### PR TITLE
fix: remove unnecessary field for pass objects with Bundle

### DIFF
--- a/app/src/main/java/com/fastaccess/ui/modules/gists/gist/files/GistFilesListFragment.java
+++ b/app/src/main/java/com/fastaccess/ui/modules/gists/gist/files/GistFilesListFragment.java
@@ -6,6 +6,7 @@ import androidx.annotation.Nullable;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import android.view.View;
 
+import com.annimon.stream.Stream;
 import com.evernote.android.state.State;
 import com.fastaccess.R;
 import com.fastaccess.data.dao.FilesListModel;
@@ -49,6 +50,7 @@ public class GistFilesListFragment extends BaseFragment<GistFilesListMvp.View, G
 
     public static GistFilesListFragment newInstance(@NonNull ArrayList<FilesListModel> files, boolean isOwner) {
         GistFilesListFragment view = new GistFilesListFragment();
+        Stream.of(files).forEach(filesListModel -> filesListModel.content = null);
         view.setArguments(Bundler.start()
                 .putParcelableArrayList(BundleConstant.ITEM, files)
                 .put(BundleConstant.EXTRA_TYPE, isOwner)


### PR DESCRIPTION
Hi.
I investigated the problem with issue #2906 
Some gist files not show, because Bundle has limitation on content in 50K. This case happened in bug report. I removed content field from object for resolve this problem. This field do not necessary and do not used in item card.