### PR TITLE
fix: viewer can't open image from markdown links (fix #1266)

### DIFF
--- a/app/src/main/java/com/prettifier/pretty/PrettifyWebView.java
+++ b/app/src/main/java/com/prettifier/pretty/PrettifyWebView.java
@@ -233,7 +233,11 @@ public class PrettifyWebView extends NestedWebView {
     private void startActivity(@Nullable Uri url) {
         if (url == null) return;
         if (MarkDownProvider.isImage(url.toString())) {
-            CodeViewerActivity.startActivity(getContext(), url.toString(), url.toString());
+            Uri rawUrl = url
+                    .buildUpon()
+                    .authority("raw.githubusercontent.com")
+                    .build();
+            CodeViewerActivity.startActivity(getContext(), rawUrl.toString().replace("blob/", ""), url.toString());
         } else {
             String lastSegment = url.getEncodedFragment();
             if (lastSegment != null || url.toString().startsWith("#") || url.toString().indexOf('#') != -1) {

--- a/app/src/main/java/com/prettifier/pretty/PrettifyWebView.java
+++ b/app/src/main/java/com/prettifier/pretty/PrettifyWebView.java
@@ -233,11 +233,19 @@ public class PrettifyWebView extends NestedWebView {
     private void startActivity(@Nullable Uri url) {
         if (url == null) return;
         if (MarkDownProvider.isImage(url.toString())) {
-            Uri rawUrl = url
-                    .buildUpon()
-                    .authority("raw.githubusercontent.com")
-                    .build();
-            CodeViewerActivity.startActivity(getContext(), rawUrl.toString().replace("blob/", ""), url.toString());
+            String rawUrl;
+            if ("github.com".equals(url.getAuthority()) && "blob".equals(url.getPathSegments().get(2))) {
+                rawUrl = url
+                        .buildUpon()
+                        .authority("raw.githubusercontent.com")
+                        .build()
+                        .toString()
+                        .replace("blob/", "");
+            } else {
+                rawUrl = url.toString();
+            }
+
+            CodeViewerActivity.startActivity(getContext(), rawUrl, url.toString());
         } else {
             String lastSegment = url.getEncodedFragment();
             if (lastSegment != null || url.toString().startsWith("#") || url.toString().indexOf('#') != -1) {


### PR DESCRIPTION
PrettifyWebView had sent github's page url to viewer and viewer had used in href and shown it as raw image url.
This pull request fix this and PrettifyWebView send image's raw url.
This fix #1266, fix #2260

I tested with this: https://gist.github.com/moko256/27399a511358196787cfdfa821d9dff1