### PR TITLE
Promote "open in browser" to default sign in method, remove "Basic Authentication"

### DIFF
--- a/app/src/main/res/layouts/main_layouts/layout/login_chooser_layout.xml
+++ b/app/src/main/res/layouts/main_layouts/layout/login_chooser_layout.xml
@@ -142,15 +142,21 @@
                         android:paddingTop="@dimen/spacing_normal">
 
                         <com.fastaccess.ui.widgets.FontTextView
-                            android:id="@+id/basicAuth"
-                            style="@style/TextAppearance.AppCompat.Title"
+                            style="@style/TextAppearance.AppCompat.Small"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:background="?selectableItemBackground"
+                            android:layout_marginTop="@dimen/spacing_xs_large"
                             android:gravity="center"
-                            android:padding="@dimen/spacing_xs_large"
-                            android:text="@string/basic_authentication"
-                            android:textColor="@color/material_green_700"/>
+                            android:text="@string/login_using_your_default_browser"/>
+
+                        <com.fastaccess.ui.widgets.FontButton
+                            android:id="@+id/browserLogin"
+                            style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="@dimen/spacing_normal"
+                            android:text="@string/open_in_browser"/>
+
 
                         <com.fastaccess.ui.widgets.FontTextView
                             style="@style/TextAppearance.AppCompat.Small"
@@ -201,34 +207,6 @@
                                 android:text="@string/enterprise"
                                 android:textColor="@color/material_purple_700"/>
                         </LinearLayout>
-
-                        <com.fastaccess.ui.widgets.FontTextView
-                            style="@style/TextAppearance.AppCompat.Small"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:background="@drawable/bottom_border"
-                            android:gravity="center"
-                            android:paddingBottom="@dimen/spacing_normal"
-                            android:paddingEnd="@dimen/spacing_large"
-                            android:paddingStart="@dimen/spacing_large"
-                            android:text="@string/or_character"/>
-
-                        <com.fastaccess.ui.widgets.FontTextView
-                            style="@style/TextAppearance.AppCompat.Small"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_xs_large"
-                            android:gravity="center"
-                            android:text="@string/login_using_your_default_browser"/>
-
-                        <com.fastaccess.ui.widgets.FontButton
-                            android:id="@+id/browserLogin"
-                            style="@style/Widget.AppCompat.Button.Borderless.Colored"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginBottom="@dimen/spacing_normal"
-                            android:text="@string/open_in_browser"/>
-
                     </LinearLayout>
                 </LinearLayout>
 


### PR DESCRIPTION
Hello, I'm from the GitHub security team. We are in the process of removing the ability to use a password to authenticate to the GitHub API. We noticed this application supports and encourages in-app password-based authentication.

We suggest you only enable the "Login with your default browser (OAuth)" option. Let us know if we can help you in any way.

Ref: https://developer.github.com/changes/2020-02-14-deprecating-password-auth/
https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/

If I did things right, this pull request simply changes the UI but does not remove any of the underlying functionality.