### PR TITLE
Prevent null reference

### DIFF
--- a/app/src/main/java/com/fastaccess/ui/adapter/viewholder/FeedsViewHolder.java
+++ b/app/src/main/java/com/fastaccess/ui/adapter/viewholder/FeedsViewHolder.java
@@ -248,7 +248,7 @@ public class FeedsViewHolder extends BaseViewHolder<Event> {
                 .append(eventsModel.getRepo().getName())
                 .bold("#")
                 .bold(String.valueOf(pullRequest.getNumber()));
-        if (comment.getBody() != null) {
+        if (comment != null && comment.getBody() != null) {
             MarkDownProvider.stripMdText(description, comment.getBody().replaceAll("\\r?\\n|\\r", " "));
             description.setVisibility(View.VISIBLE);
         } else {


### PR DESCRIPTION
Sometimes comment gets set to null, so I've added a check to make sure it's not null when we reference it. Referencing [issue#2968](https://github.com/k0shk0sh/FastHub/issues/2968)